### PR TITLE
Clean up the deprecation warnings when running tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.32.5
+ - ref: int/bool deprecation warnings in numpy 1.20.0 (#39)
 0.32.4
  - fix: TypeError when registering emodulus LUT (#91)
  - ref: minor cleanup

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.32.5
- - ref: int/bool deprecation warnings in numpy 1.20.0 (#39)
+ - ref: int/bool deprecation warnings in numpy 1.20.0 (#93)
 0.32.4
  - fix: TypeError when registering emodulus LUT (#91)
  - ref: minor cleanup

--- a/dclab/features/emodulus/load.py
+++ b/dclab/features/emodulus/load.py
@@ -77,7 +77,7 @@ def load_lut(lut_data="LE-2D-FEM-19"):
 
 
 def load_mtext(path):
-    """Load colunm-based data from text files with metadata
+    """Load column-based data from text files with metadata
 
     This file format is used for isoelasticity lines and look-up
     table data in dclab.

--- a/dclab/features/inert_ratio.py
+++ b/dclab/features/inert_ratio.py
@@ -29,7 +29,7 @@ def cont_moments_cv(cont,
     """
     # Make sure we have no unsigned integers
     if np.issubdtype(cont.dtype, np.unsignedinteger):
-        cont = cont.astype(np.int)
+        cont = cont.astype(int)
 
     xi = cont[:, 0]
     yi = cont[:, 1]

--- a/dclab/kde_methods.py
+++ b/dclab/kde_methods.py
@@ -26,7 +26,7 @@ def bin_num_doane(a):
     if acc == 0 or np.isnan(acc):
         num = 5
     else:
-        num = np.int(np.round((data.max() - data.min()) / acc))
+        num = int(np.round((data.max() - data.min()) / acc))
     return num
 
 

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -478,7 +478,7 @@ class RTDCBase(object):
             Identifier for Y axis
         positions: list of two 1d ndarrays or ndarray of shape (2, N)
             The positions where the KDE will be computed. Note that
-            the KDE estimate is computed from the the points that
+            the KDE estimate is computed from the points that
             are set in `self.filter.all`.
         kde_type: str
             The KDE method to use

--- a/dclab/rtdc_dataset/fmt_hierarchy.py
+++ b/dclab/rtdc_dataset/fmt_hierarchy.py
@@ -213,7 +213,7 @@ class RTDC_Hierarchy(RTDCBase):
         hparent: instance of RTDCBase
             The hierarchy parent
         apply_filter: bool
-            Whether to apply the filter durint instantiation;
+            Whether to apply the filter during instantiation;
             If set to `False`, `apply_filter` must be called
             manually.
         *args:

--- a/tests/test_rtdc_write_hdf5.py
+++ b/tests/test_rtdc_write_hdf5.py
@@ -303,7 +303,7 @@ def test_real_time():
     shy = 32
     contours = [np.arange(20).reshape(10, 2)] * M
     images = np.zeros((M, shy, shx), dtype=np.uint8)
-    masks = np.zeros((M, shy, shx), dtype=np.bool)
+    masks = np.zeros((M, shy, shx), dtype=np.bool_)
     traces = {"fl1_median": np.arange(M * 55).reshape(M, 55)}
     axis1 = np.linspace(0, 1, M)
     axis2 = np.arange(M)
@@ -334,8 +334,8 @@ def test_real_time():
         assert events["area_um"].shape == (N,)
         assert events["contour"]["0"].shape == (10, 2)
         assert events["trace"]["fl1_median"].shape == (N, 55)
-        assert np.dtype(events["area_um"]) == np.float
-        assert np.dtype(events["area_cvx"]) == np.int
+        assert np.dtype(events["area_um"]) == float
+        assert np.dtype(events["area_cvx"]) == int
 
 
 def test_real_time_single():
@@ -344,7 +344,7 @@ def test_real_time_single():
     shx = 30
     shy = 10
     image = np.zeros((shy, shx), dtype=np.uint8)
-    mask = np.zeros((shy, shx), dtype=np.bool)
+    mask = np.zeros((shy, shx), dtype=np.bool_)
     contour = np.arange(22).reshape(11, 2)
     trace = {"fl1_median": np.arange(43)}
 
@@ -372,8 +372,8 @@ def test_real_time_single():
         assert events["area_um"].shape == (N,)
         assert events["contour"]["0"].shape == (11, 2)
         assert events["trace"]["fl1_median"].shape == (N, 43)
-        assert np.dtype(events["area_um"]) == np.float
-        assert np.dtype(events["area_cvx"]) == np.int
+        assert np.dtype(events["area_um"]) == float
+        assert np.dtype(events["area_cvx"]) == int
         logs = rtdc_data["logs"]
         assert len(logs["log1"]) == N
 


### PR DESCRIPTION
This PR will clean up the deprecation warnings when running tests. Fixes issue #93.