### PR TITLE
Test for area_cvx as a float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,16 @@ docs/dclab.bib.sav
 *.yml~
 *.rst~
 
-_version_save.py
+# Environments
 .env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+_version_save.py
 *.bib.bak
 .pytest_cache
 pip-wheel-metadata

--- a/docs/sec_av_ml.rst
+++ b/docs/sec_av_ml.rst
@@ -157,7 +157,7 @@ The corresponding index.json file could look like this:
             "ml_score_sad"
           ],
           "output labels": [
-            "red boold cells",
+            "red blood cells",
             "sad cells"
           ],
           "path": "model_1",

--- a/tests/test_rtdc_write_hdf5.py
+++ b/tests/test_rtdc_write_hdf5.py
@@ -335,7 +335,7 @@ def test_real_time():
         assert events["contour"]["0"].shape == (10, 2)
         assert events["trace"]["fl1_median"].shape == (N, 55)
         assert np.dtype(events["area_um"]) == float
-        assert np.dtype(events["area_cvx"]) == int
+        assert np.dtype(events["area_cvx"]) == float
 
 
 def test_real_time_single():
@@ -373,7 +373,7 @@ def test_real_time_single():
         assert events["contour"]["0"].shape == (11, 2)
         assert events["trace"]["fl1_median"].shape == (N, 43)
         assert np.dtype(events["area_um"]) == float
-        assert np.dtype(events["area_cvx"]) == int
+        assert np.dtype(events["area_cvx"]) == float
         logs = rtdc_data["logs"]
         assert len(logs["log1"]) == N
 

--- a/tests/test_rtdc_write_hdf5.py
+++ b/tests/test_rtdc_write_hdf5.py
@@ -306,7 +306,7 @@ def test_real_time():
     masks = np.zeros((M, shy, shx), dtype=np.bool_)
     traces = {"fl1_median": np.arange(M * 55).reshape(M, 55)}
     axis1 = np.linspace(0, 1, M)
-    axis2 = np.arange(M)
+    axis2 = np.arange(float(M))
     rtdc_file = tempfile.mktemp(suffix=".rtdc",
                                 prefix="dclab_test_realtime_")
     with h5py.File(rtdc_file, "w") as fobj:
@@ -354,7 +354,7 @@ def test_real_time_single():
         # simulate real time and write one image at a time
         for ii in range(N):
             data = {"area_um": ii * .1,
-                    "area_cvx": ii * 5,
+                    "area_cvx": ii * 5.,
                     "image": image * ii,
                     "contour": contour,
                     "mask": mask,


### PR DESCRIPTION
PR aim is to test for `area_cvx` as a float, consistent with output from ShapeIn. Closes #96. 

@paulmueller separate thing that could be thrown in with this PR: Is there a reason why the .gitignore in dclab doesn't include environment paths such as `venv/`? I could put this is a separate PR also.