### PR TITLE
Correct the docstring of `get_volume`

### DIFF
--- a/dclab/features/volume.py
+++ b/dclab/features/volume.py
@@ -25,7 +25,7 @@ def get_volume(cont, pos_x, pos_y, pix):
         e.g. obtained using `mm.pos_y`
     px_um: float
         The detector pixel size in µm.
-        e.g. obtained using: `mm.config["image"]["pix size"]`
+        e.g. obtained using: `mm.config["imaging"]["pixel size"]`
 
     Returns
     -------


### PR DESCRIPTION
The docstring of the `get_volume` function stated: `mm.config["image"]["pix size"]` when it should be `mm.config["imaging"]["pixel size"]`.
