### PR TITLE
docs: add autodoc to constant variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ coverage.xml
 # Django stuff:
 *.log
 
+# Vim stuff:
+*~
+*.swp
+*.swo
 
 # Cython
 *.c

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.32.5
+ - docs: add autodoc to constant variables (#94)
  - ref: int/bool deprecation warnings in numpy 1.20.0 (#93)
  - tests: test for area_cvx as a float, consistent with output from
    Shape-In (#96)

--- a/dclab/definitions.py
+++ b/dclab/definitions.py
@@ -229,7 +229,7 @@ for _i in range(10):
                             "User defined {}".format(_i)
                             ])
 
-#: List of non-scalar features
+#: list of non-scalar features
 FEATURES_NON_SCALAR = [
     # This is a (M, 2)-shaped array with integer contour coordinates
     ["contour", "Binary event contour image"],

--- a/docs/sec_code_reference.rst
+++ b/docs/sec_code_reference.rst
@@ -25,28 +25,20 @@ Valid configuration sections and keys are described in:
 :ref:`sec_analysis_meta` and :ref:`sec_experiment_meta`.
 
 
-.. data:: dclab.dfn.CFG_ANALYSIS
+.. autodata:: dclab.definitions.CFG_ANALYSIS
+   :no-value:
 
-    User-editable configuration for data analysis.
-    
-.. data:: dclab.dfn.CFG_METADATA
+.. autodata:: dclab.definitions.CFG_METADATA
+   :no-value:
 
-    Measurement-specific metadata.
+.. autodata:: dclab.definitions.config_funcs
+   :no-value:
 
-.. data:: dclab.dfn.config_funcs
+.. autodata:: dclab.definitions.config_keys
+   :no-value:
 
-    Dictionary of dictionaries containing functions to convert input data
-    to the predefined data type
-
-.. data:: dclab.dfn.config_keys
-
-    Dictionary with sections as keys and configuration parameter
-    names as values
-
-.. data:: dclab.dfn.config_types
-
-    Dictionary of dictionaries containing the data type of each
-    configuration parameter
+.. autodata:: dclab.definitions.config_types
+   :no-value:
 
 
 features
@@ -54,32 +46,27 @@ features
 Features are discussed in more detail in: :ref:`sec_features`.
 
 
-.. autofunction:: dclab.dfn.feature_exists
+.. autofunction:: dclab.definitions.feature_exists
 
-.. autofunction:: dclab.dfn.get_feature_label
+.. autofunction:: dclab.definitions.get_feature_label
 
-.. autofunction:: dclab.dfn.scalar_feature_exists
+.. autofunction:: dclab.definitions.scalar_feature_exists
 
 
-.. data:: dclab.dfn.FEATURES_NON_SCALAR
+.. autodata:: dclab.definitions.FEATURES_NON_SCALAR
+   :no-value:
 
-    Non-scalar features
+.. autodata:: dclab.definitions.feature_names
+   :no-value:
 
-.. data:: dclab.dfn.feature_names
+.. autodata:: dclab.definitions.feature_labels
+   :no-value:
 
-    List of valid feature names
+.. autodata:: dclab.definitions.feature_name2label
+   :no-value:
 
-.. data:: dclab.dfn.feature_labels
-
-    List of human-readable labels for each valid feature
-
-.. data:: dclab.dfn.feature_name2label
-
-    Dictionary that maps feature names to feature labels
-
-.. data:: dclab.dfn.scalar_feature_names
-
-    List of valid scalar feature names
+.. autodata:: dclab.definitions.scalar_feature_names
+   :no-value:
 
 parse functions
 ---------------


### PR DESCRIPTION
This commit changes RTD-documentation for constants
in 'sec_code_reference.rst' from hardcoded to
automated.