### PR TITLE
fix: add check for negative fluorescence values (#101)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.33.0
+ - fix: add check for negative fluorescence values (#101)
  - feat: introduce user-defined temporary features (point 2 in #98)
 0.32.5
  - fix: add check for zero-flow rate in dclab-verify-dataset

--- a/dclab/rtdc_dataset/check.py
+++ b/dclab/rtdc_dataset/check.py
@@ -392,7 +392,7 @@ class IntegrityChecker(object):
         return cues
 
     def check_fl_max_positive(self, **kwargs):
-        """ Check if all fl?_max values are >0.1 """
+        """Check if all fl?_max values are >0.1"""
         cues = []
         neg_feats = []
         for fl in ['fl1_max', 'fl2_max', 'fl3_max']:
@@ -401,13 +401,14 @@ class IntegrityChecker(object):
                     neg_feats.append(fl)
         if neg_feats:
             cues.append(ICue(
-                msg="Negative value for feature {}".format(neg_feats),
+                msg="Negative value for feature(s): {}".format(
+                    ", ".join(neg_feats)),
                 level="alert",
                 category="feature data"))
         return cues
 
     def check_fl_max_ctc_positive(self, **kwargs):
-        """ Check if all fl?_max_ctc values are > 0.1 """
+        """Check if all fl?_max_ctc values are > 0.1"""
         cues = []
         neg_feats = []
         for fl in ['fl1_max_ctc', 'fl2_max_ctc', 'fl3_max_ctc']:
@@ -416,7 +417,8 @@ class IntegrityChecker(object):
                     neg_feats.append(fl)
         if neg_feats:
             cues.append(ICue(
-                msg="Negative value for feature {}".format(neg_feats),
+                msg="Negative value for feature(s): {}".format(
+                    ", ".join(neg_feats)),
                 level="alert",
                 category="feature data"))
         return cues

--- a/dclab/rtdc_dataset/check.py
+++ b/dclab/rtdc_dataset/check.py
@@ -391,6 +391,36 @@ class IntegrityChecker(object):
                             cfg_key="samples per event"))
         return cues
 
+    def check_fl_max_positive(self, **kwargs):
+        """ Check if all fl?_max values are >0.1 """
+        cues = []
+        neg_feats = []
+        for fl in ['fl1_max', 'fl2_max', 'fl3_max']:
+            if fl in self.ds:
+                if min(self.ds[fl]) <= 0.1:
+                    neg_feats.append(fl)
+        if neg_feats:
+            cues.append(ICue(
+                msg="Negative value for feature {}".format(neg_feats),
+                level="alert",
+                category="feature data"))
+        return cues
+
+    def check_fl_max_ctc_positive(self, **kwargs):
+        """ Check if all fl?_max_ctc values are > 0.1 """
+        cues = []
+        neg_feats = []
+        for fl in ['fl1_max_ctc', 'fl2_max_ctc', 'fl3_max_ctc']:
+            if fl in self.ds:
+                if min(self.ds[fl]) <= 0.1:
+                    neg_feats.append(fl)
+        if neg_feats:
+            cues.append(ICue(
+                msg="Negative value for feature {}".format(neg_feats),
+                level="alert",
+                category="feature data"))
+        return cues
+
     def check_flow_rate(self, **kwargs):
         """Make sure sheath and sample flow rates add up"""
         cues = []

--- a/tests/test_rtdc_check_dataset.py
+++ b/tests/test_rtdc_check_dataset.py
@@ -69,6 +69,7 @@ def test_exact():
         "Metadata: Missing key [online_contour] 'no absdiff'",
         "Metadata: Missing key [setup] 'identifier'",
         "Metadata: Missing key [setup] 'module composition'",
+        "Negative value for feature ['fl2_max']",
     ]
     known_info = [
         'Compression: None',
@@ -289,6 +290,44 @@ def test_ic_metadata_empty_string():
     assert cues[0].level == "violation"
     assert cues[0].cfg_section == "setup"
     assert cues[0].cfg_key == "medium"
+
+
+def test_ic_fl_max():
+    # Testing dataset with negative fl_max values
+    ddict = example_data_dict(size=8472, keys=["fl1_max"])
+    ddict["fl1_max"] -= min(ddict["fl1_max"]) + 1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_positive()
+    assert cues[0].level == "alert"
+    assert cues[0].category == "feature data"
+
+    # Testing dataset without negative fl_max values
+    ddict = example_data_dict(size=8472, keys=["fl1_max"])
+    ddict["fl1_max"] -= min(ddict["fl1_max"]) - 1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_positive()
+    assert not cues
+
+
+def test_ic_fl_max_ctc():
+    # Testing dataset with negative fl_max_ctc values
+    ddict = example_data_dict(size=8472, keys=["fl1_max_ctc"])
+    ddict["fl1_max_ctc"] -= min(ddict["fl1_max_ctc"]) + 1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_ctc_positive()
+    assert cues[0].level == "alert"
+    assert cues[0].category == "feature data"
+
+    # Testing dataset without negative fl_max_ctc values
+    ddict = example_data_dict(size=8472, keys=["fl1_max_ctc"])
+    ddict["fl1_max_ctc"] -= min(ddict["fl1_max_ctc"]) - 1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_ctc_positive()
+    assert not cues
 
 
 @pytest.mark.filterwarnings('ignore::dclab.rtdc_dataset.'

--- a/tests/test_rtdc_check_dataset.py
+++ b/tests/test_rtdc_check_dataset.py
@@ -69,7 +69,7 @@ def test_exact():
         "Metadata: Missing key [online_contour] 'no absdiff'",
         "Metadata: Missing key [setup] 'identifier'",
         "Metadata: Missing key [setup] 'module composition'",
-        "Negative value for feature ['fl2_max']",
+        "Negative value for feature(s): fl2_max",
     ]
     known_info = [
         'Compression: None',
@@ -302,7 +302,16 @@ def test_ic_fl_max():
     assert cues[0].level == "alert"
     assert cues[0].category == "feature data"
 
-    # Testing dataset without negative fl_max values
+    # Testing dataset with fl_max values of 0.1
+    ddict = example_data_dict(size=8472, keys=["fl1_max"])
+    ddict["fl1_max"] -= min(ddict["fl1_max"]) - 0.1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_positive()
+    assert cues[0].level == "alert"
+    assert cues[0].category == "feature data"
+
+    # Testing dataset with fl_max values > 0.1
     ddict = example_data_dict(size=8472, keys=["fl1_max"])
     ddict["fl1_max"] -= min(ddict["fl1_max"]) - 1
     ds = new_dataset(ddict)
@@ -321,7 +330,16 @@ def test_ic_fl_max_ctc():
     assert cues[0].level == "alert"
     assert cues[0].category == "feature data"
 
-    # Testing dataset without negative fl_max_ctc values
+    # Testing dataset with fl_max_ctc values of 0.1
+    ddict = example_data_dict(size=8472, keys=["fl1_max_ctc"])
+    ddict["fl1_max_ctc"] -= min(ddict["fl1_max_ctc"]) - 0.1
+    ds = new_dataset(ddict)
+    with check.IntegrityChecker(ds) as ic:
+        cues = ic.check_fl_max_ctc_positive()
+    assert cues[0].level == "alert"
+    assert cues[0].category == "feature data"
+
+    # Testing dataset with fl_max_ctc values > 0.1
     ddict = example_data_dict(size=8472, keys=["fl1_max_ctc"])
     ddict["fl1_max_ctc"] -= min(ddict["fl1_max_ctc"]) - 1
     ds = new_dataset(ddict)


### PR DESCRIPTION
Due to baseline deviations from 0, negative maximum
fluorenscence values might be introduced. This leads
to issues when plotting the data, since often a
log scale is used. To notify about negative fl-values
new dataset-checks were implemented.