### PR TITLE
fix: catch errors for integrity checks on non-raw datasets (#102)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.33.0
+ - fix: catch errors for integrity checks on non-raw datasets (#102)
  - fix: add check for negative fluorescence values (#101)
  - feat: introduce user-defined temporary features (point 2 in #98)
  - setup: remove deprecated setup.py test

--- a/dclab/rtdc_dataset/check.py
+++ b/dclab/rtdc_dataset/check.py
@@ -200,10 +200,14 @@ class IntegrityChecker(object):
         """
         cues = []
         funcs = IntegrityChecker.__dict__
-        if (not len(self.ds) == np.sum(self.ds.filter.all) or
-           self.ds.__class__ == RTDC_Hierarchy):
+        if not len(self.ds) == np.sum(self.ds.filter.all):
             raise NotImplementedError(
-                    "Cannot run IntegrityChecker on altered Datasets.")
+                    "Integrity checks for datasets with active event filters "
+                    "are not supported!")
+        elif self.ds.__class__ == RTDC_Hierarchy:
+            raise NotImplementedError(
+                    "Integrity checks for 'RTDC_Hierarchy' instances are "
+                    "not supported!")
         for ff in sorted(funcs.keys()):
             if ff.startswith("check_fl_") and not self.has_fluorescence:
                 # skip

--- a/dclab/rtdc_dataset/check.py
+++ b/dclab/rtdc_dataset/check.py
@@ -8,6 +8,7 @@ import h5py
 import numpy as np
 
 from .core import RTDCBase
+from .fmt_hierarchy import RTDC_Hierarchy
 from .load import load_file
 
 from .. import definitions as dfn
@@ -199,6 +200,10 @@ class IntegrityChecker(object):
         """
         cues = []
         funcs = IntegrityChecker.__dict__
+        if (not len(self.ds) == np.sum(self.ds.filter.all) or
+           self.ds.__class__ == RTDC_Hierarchy):
+            raise NotImplementedError(
+                    "Cannot run IntegrityChecker on altered Datasets.")
         for ff in sorted(funcs.keys()):
             if ff.startswith("check_fl_") and not self.has_fluorescence:
                 # skip

--- a/tests/test_rtdc_check_dataset.py
+++ b/tests/test_rtdc_check_dataset.py
@@ -350,22 +350,22 @@ def test_ic_fl_max_ctc():
 
 def test_ic_invalid_dataset():
     # Testing if IC throws NotImplementedError for hierarchy datasets
-    with pytest.raises(NotImplementedError):
-        ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
-        ds = new_dataset(ddict)
-        ds_child = new_dataset(ds)
-        with check.IntegrityChecker(ds_child) as ic:
+    ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
+    ds = new_dataset(ddict)
+    ds_child = new_dataset(ds)
+    with check.IntegrityChecker(ds_child) as ic:
+        with pytest.raises(NotImplementedError):
             ic.check()
 
     # Testing if IC throws NotImplementedError for raw-datasets with
     # applied filters
-    with pytest.raises(NotImplementedError):
-        ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
-        ds = new_dataset(ddict)
-        ds.config["filtering"]["area_um max"] = 100
-        ds.config["filtering"]["area_um min"] = 1
-        ds.apply_filter()
-        with check.IntegrityChecker(ds) as ic:
+    ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
+    ds = new_dataset(ddict)
+    ds.config["filtering"]["area_um max"] = 100
+    ds.config["filtering"]["area_um min"] = 1
+    ds.apply_filter()
+    with check.IntegrityChecker(ds) as ic:
+        with pytest.raises(NotImplementedError):
             ic.check()
 
 

--- a/tests/test_rtdc_check_dataset.py
+++ b/tests/test_rtdc_check_dataset.py
@@ -348,6 +348,27 @@ def test_ic_fl_max_ctc():
     assert not cues
 
 
+def test_ic_invalid_dataset():
+    # Testing if IC throws NotImplementedError for hierarchy datasets
+    with pytest.raises(NotImplementedError):
+        ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
+        ds = new_dataset(ddict)
+        ds_child = new_dataset(ds)
+        with check.IntegrityChecker(ds_child) as ic:
+            ic.check()
+
+    # Testing if IC throws NotImplementedError for raw-datasets with
+    # applied filters
+    with pytest.raises(NotImplementedError):
+        ddict = example_data_dict(size=8472, keys=["area_um", "deform"])
+        ds = new_dataset(ddict)
+        ds.config["filtering"]["area_um max"] = 100
+        ds.config["filtering"]["area_um min"] = 1
+        ds.apply_filter()
+        with check.IntegrityChecker(ds) as ic:
+            ic.check()
+
+
 @pytest.mark.filterwarnings('ignore::dclab.rtdc_dataset.'
                             + 'ancillaries.ancillary_feature.'
                             + 'BadFeatureSizeWarning')


### PR DESCRIPTION
Integrity checks are only supposed to run on raw datasets and not
on dataset with applied filters or hierarchy datasets. To catch
missuse, a 'NotImplementedError' was added for such cases.
Fixes #102