### PR TITLE
feat: add new metadata keys for baseline offset (#107)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.33.0
+ - feat: add metadata keys for baseline offset (#107)
  - fix: add check for negative fluorescence values (#101)
  - feat: introduce user-defined temporary features (point 2 in #98)
  - setup: remove deprecated setup.py test

--- a/dclab/definitions.py
+++ b/dclab/definitions.py
@@ -72,6 +72,9 @@ CFG_METADATA = {
         ["signal max", float, "Upper voltage detection limit [V]"],
         ["signal min", float, "Lower voltage detection limit [V]"],
         ["trace median", fint, "Rolling median filter size for traces"],
+        ["baseline 1 offset", fint, "Baseline offset channel 1"],
+        ["baseline 2 offset", fint, "Baseline offset channel 2"],
+        ["baseline 3 offset", fint, "Baseline offset channel 3"],
     ],
     # All tdms-related parameters
     "fmt_tdms": [


### PR DESCRIPTION
These new metadata keys will enable the computation of baseline
offsets of the fluorescence channel traces. Fixes #107.