### PR TITLE
bug: aspect was misspelled in FEATURES_RAPID

### DIFF
--- a/dclab/rtdc_dataset/ancillaries/__init__.py
+++ b/dclab/rtdc_dataset/ancillaries/__init__.py
@@ -11,7 +11,7 @@ from . import af_ml_score  # noqa: F401
 FEATURES_RAPID = [
     "area_ratio",
     "area_um",
-    "aspec",
+    "aspect",
     "deform",
     "index",
     "time",


### PR DESCRIPTION
Is `"aspec"` a misspelling of `"aspect"`? Or is `aspec` something else...

In `dclab/rtdc_dataset/ancillaries/__init__.py` 
```
#: features whose computation is fast
FEATURES_RAPID = [
    "area_ratio",
    "area_um",
    "aspec",
    "deform",
    "index",
    "time",
]
```