### PR TITLE
feat: add offset correction to cli-functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.33.0
+ - feat: add offset correction to cli-functions
  - fix: catch errors for integrity checks on non-raw datasets (#102)
  - feat: add metadata keys for baseline offset (#107)
  - fix: add check for negative fluorescence values (#101)

--- a/dclab/cli.py
+++ b/dclab/cli.py
@@ -6,6 +6,7 @@ import json
 import pathlib
 import platform
 import shutil
+import tempfile
 import warnings
 
 import h5py
@@ -14,6 +15,7 @@ import numpy as np
 from .rtdc_dataset import check_dataset, export, fmt_tdms, new_dataset, \
     write_hdf5
 from .rtdc_dataset.check import IntegrityChecker
+from . import correct
 from . import definitions as dfn
 from . import util
 from ._version import version
@@ -122,7 +124,7 @@ def print_violation(string):
     print_info("\033[31m{}".format(string))
 
 
-def compress(path_out=None, path_in=None, force=False):
+def compress(path_out=None, path_in=None, force=False, correct_offset=False):
     """Create a new dataset with all features compressed losslessly"""
     if path_out is None or path_in is None:
         parser = compress_parser()
@@ -130,6 +132,7 @@ def compress(path_out=None, path_in=None, force=False):
         path_in = args.input
         path_out = args.output
         force = args.force
+        correct_offset = args.correct_offset
 
     path_in = pathlib.Path(path_in)
     path_out = pathlib.Path(path_out)
@@ -143,12 +146,24 @@ def compress(path_out=None, path_in=None, force=False):
     if not force:
         # Check whether the input file is already compressed
         # (This is not done in force-mode)
-        ic = IntegrityChecker(path_in)
-        cue = ic.check_compression()[0]
-        if cue.data["uncompressed"] == 0:
-            # we are done here
-            shutil.copy2(path_in, path_out)  # copy with metadata
-            return
+        with IntegrityChecker(path_in) as ic:
+            cue = ic.check_compression()[0]
+            if cue.data["uncompressed"] == 0:
+                # we are done here
+                # correct.offset implicitly uses shutil.copy2
+                if correct_offset:
+                    correct.offset(path_in=path_in, path_out=path_out)
+                else:
+                    shutil.copy2(path_in, path_out)  # copy with metadata
+                return
+
+    if correct_offset:
+        # Cache file with corrected offset
+        tmp_dir = tempfile.mkdtemp()
+        temp_path = pathlib.Path(tmp_dir, path_in.name)
+        correct.offset(path_in=path_in, path_out=temp_path)
+        # Set path to temporary file (corrected offset) as new path_in
+        path_in = temp_path
 
     logs = {}
 
@@ -174,6 +189,9 @@ def compress(path_out=None, path_in=None, force=False):
                           compression="gzip"):
         pass
 
+    if correct_offset:
+        shutil.rmtree(tmp_dir)
+
 
 def compress_parser():
     descr = "Create a compressed version of an .rtdc file. This can be " \
@@ -190,6 +208,12 @@ def compress_parser():
                         help='Force compression, even if the input dataset '
                              + 'is already compressed.')
     parser.set_defaults(force=False)
+    parser.add_argument('--correct-offset',
+                        dest='correct_offset',
+                        action='store_true',
+                        help='If \'True\' applies offset correction to '
+                             + 'fl?_max values')
+    parser.set_defaults(correct_offset=False)
     return parser
 
 
@@ -245,13 +269,14 @@ def condense_parser():
 
 
 def join(path_out=None, paths_in=None,
-         metadata={"experiment": {"run index": 1}}):
+         metadata={"experiment": {"run index": 1}}, correct_offset=False):
     """Join multiple RT-DC measurements into a single .rtdc file"""
     if path_out is None or paths_in is None:
         parser = join_parser()
         args = parser.parse_args()
         paths_in = args.input
         path_out = args.output
+        correct_offset = args.correct_offset
 
     if len(paths_in) < 2:
         raise ValueError("At least two input files must be specified!")
@@ -262,6 +287,13 @@ def join(path_out=None, paths_in=None,
 
     if path_out.exists():
         raise ValueError("Output file '{}' already exists!".format(path_out))
+
+    if correct_offset:
+        # Store actual 'path_out' for saving the corrected file later
+        correct_path_out = path_out
+        tmp_dir = tempfile.mkdtemp()
+        temp_path = pathlib.Path(tmp_dir, path_out.name)
+        path_out = temp_path
 
     # Determine input file order
     key_paths = []
@@ -338,6 +370,10 @@ def join(path_out=None, paths_in=None,
                           compression="gzip"):
         pass
 
+    if correct_offset:
+        correct.offset(path_in=path_out, path_out=correct_path_out)
+        shutil.rmtree(tmp_dir)
+
 
 def join_parser():
     descr = "Join two or more RT-DC measurements. This will produce " \
@@ -348,6 +384,12 @@ def join_parser():
     parser = argparse.ArgumentParser(description=descr)
     parser.add_argument('input', metavar="INPUT", nargs="*", type=str,
                         help='Input paths (.tdms or .rtdc files)')
+    parser.add_argument('--correct-offset',
+                        dest='correct_offset',
+                        action='store_true',
+                        help='If \'True\' applies offset correction to '
+                             + 'fl?_max values')
+    parser.set_defaults(correct_offset=False)
     requiredNamed = parser.add_argument_group('required named arguments')
     requiredNamed.add_argument('-o', '--output', metavar="OUTPUT", type=str,
                                help='Output path (.rtdc file)', required=True)
@@ -433,7 +475,7 @@ def skip_empty_image_events(ds, initial=True, final=True):
 
 def split(path_in=None, path_out=None, split_events=10000,
           skip_initial_empty_image=True, skip_final_empty_image=True,
-          ret_out_paths=False, verbose=False):
+          ret_out_paths=False, verbose=False, correct_offset=False):
     """Split a measurement file
 
     Parameters
@@ -446,6 +488,8 @@ def split(path_in=None, path_out=None, split_events=10000,
         Maximum number of events in each output file
     verbose: bool
         If `True`, print messages to stdout
+    correct_offset: bool
+        If 'True', applies offset correction to fl?_max values
     """
     if path_in is None:
         parser = split_parser()
@@ -457,10 +501,21 @@ def split(path_in=None, path_out=None, split_events=10000,
         skip_initial_empty_image = not args.include_empty_boundary_images
         skip_final_empty_image = not args.include_empty_boundary_images
         verbose = True
+        correct_offset = args.correct_offset
+
     if path_out in ["PATH_IN", None]:  # default to input directory
         path_out = path_in.parent
     path_in = pathlib.Path(path_in)
     path_out = pathlib.Path(path_out)
+
+    if correct_offset:
+        # Cache file with corrected offset
+        tmp_dir = tempfile.mkdtemp()
+        temp_path = pathlib.Path(tmp_dir, path_in.name)
+        correct.offset(path_in=path_in, path_out=temp_path)
+        # Set path to temporary file (corrected offset) as new path_in
+        path_in = temp_path
+
     logs = {}
     logs["dclab-split"] = get_command_log(paths=[path_in])
     paths_gen = []
@@ -510,6 +565,9 @@ def split(path_in=None, path_out=None, split_events=10000,
                               compression="gzip"):
             pass
 
+    if correct_offset:
+        shutil.rmtree(tmp_dir)
+
     if ret_out_paths:
         return paths_gen
 
@@ -535,13 +593,18 @@ def split_parser():
                              + 'this option, if you wish to include these '
                              + 'events with empty image data.')
     parser.set_defaults(include_empty_boundary_images=False)
-
+    parser.add_argument('--correct-offset',
+                        dest='correct_offset',
+                        action='store_true',
+                        help='If \'True\' applies offset correction to '
+                             + 'fl?_max values')
+    parser.set_defaults(correct_offset=False)
     return parser
 
 
 def tdms2rtdc(path_tdms=None, path_rtdc=None, compute_features=False,
               skip_initial_empty_image=True, skip_final_empty_image=True,
-              verbose=False):
+              verbose=False, correct_offset=False):
     """Convert .tdms datasets to the hdf5-based .rtdc file format
 
     Parameters
@@ -564,6 +627,8 @@ def tdms2rtdc(path_tdms=None, path_rtdc=None, compute_features=False,
         final image is not included in the resulting .rtdc file.
     verbose: bool
         If `True`, print messages to stdout
+    correct_offset: bool
+        If 'True', applies offset correction to fl?_max values
     """
     if path_tdms is None or path_rtdc is None:
         parser = tdms2rtdc_parser()
@@ -575,6 +640,7 @@ def tdms2rtdc(path_tdms=None, path_rtdc=None, compute_features=False,
         skip_initial_empty_image = not args.include_empty_boundary_images
         skip_final_empty_image = not args.include_empty_boundary_images
         verbose = True
+        correct_offset = args.correct_offset
 
     if not path_tdms.suffix == ".tdms":
         raise ValueError("Please specify a .tdms file!")
@@ -597,6 +663,13 @@ def tdms2rtdc(path_tdms=None, path_rtdc=None, compute_features=False,
     else:
         files_tdms = [path_tdms]
         files_rtdc = [path_rtdc]
+
+    if correct_offset:
+        # Store original output paths
+        correct_files_rtdc = files_rtdc[:]
+        # Create temporary filepath
+        tmp_dir = tempfile.mkdtemp()
+        files_rtdc = [pathlib.Path(tmp_dir, el.name) for el in files_rtdc]
 
     for ii in range(len(files_tdms)):
         ff = pathlib.Path(files_tdms[ii])
@@ -665,6 +738,13 @@ def tdms2rtdc(path_tdms=None, path_rtdc=None, compute_features=False,
                                       compression="gzip"):
                     pass
 
+        if correct_offset:
+            path_out = correct_files_rtdc[ii]
+            correct.offset(path_in=fr, path_out=path_out)
+
+    if correct_offset:
+        shutil.rmtree(tmp_dir)
+
 
 def tdms2rtdc_parser():
     descr = "Convert RT-DC .tdms files to the hdf5-based .rtdc file format. " \
@@ -700,6 +780,12 @@ def tdms2rtdc_parser():
     parser.add_argument('rtdc_path', metavar="RTDC_PATH", type=str,
                         help='Output path (file or folder), existing data '
                              + 'will be overridden')
+    parser.add_argument('--correct-offset',
+                        dest='correct_offset',
+                        action='store_true',
+                        help='If \'True\' applies offset correction to '
+                             + 'fl?_max values')
+    parser.set_defaults(correct_offset=False)
     return parser
 
 

--- a/dclab/correct.py
+++ b/dclab/correct.py
@@ -1,0 +1,49 @@
+"""Functions used to correct RTDC-files"""
+
+import pathlib
+import shutil
+
+import h5py
+import numpy as np
+
+
+def offset(path_in, path_out):
+    """Computes trace offset and corrects features "fl?_max" accordingly
+
+    Parameters
+    ----------
+    path_in: str or pathlib.Path
+        Path of input file for which the offset will be corrected.
+    path_out: str or pathlib.Path
+        Path where file with corrected offset will be saved
+    """
+    path_in = pathlib.Path(path_in)
+    path_out = pathlib.Path(path_out)
+
+    if path_out.suffix != ".rtdc":
+        path_out = path_out.with_name(path_out.name + ".rtdc")
+
+    if path_out.exists():
+        raise ValueError("Output file '{}' already exists!".format(path_out))
+
+    shutil.copy2(path_in, path_out)
+
+    with h5py.File(path_out, 'r+') as hf:
+        ds = hf["events"]
+
+        for ii in range(1, 4):
+            # skip if offset already corrected
+            feat = "fl{}_raw".format(ii)
+            feat_max = "fl{}_max".format(ii)
+            baseline_str = "fluorescence:baseline {} offset".format(ii)
+
+            if baseline_str in hf.attrs:
+                continue
+
+            if feat in ds["trace"] and feat_max in ds:
+                trace = ds["trace"][feat]
+                offset = np.min(trace)
+                # Only consider negative offsets
+                offset = min(offset, 1)
+                hf.attrs["fluorescence:baseline {} offset".format(ii)] = offset
+                ds["fl{}_max".format(ii)][:] -= (offset-1)

--- a/tests/test_correct.py
+++ b/tests/test_correct.py
@@ -1,0 +1,26 @@
+"""Test correct-functions"""
+
+from dclab import correct, new_dataset
+import h5py
+import numpy as np
+
+from helper_methods import retrieve_data
+
+
+def test_correct_offset():
+    # Arrange
+    path_in = retrieve_data("rtdc_data_hdf5_rtfdc.zip")
+    path_out = path_in.with_name("corrected.rtdc")
+
+    with h5py.File(path_in, 'r+') as hf:
+        fl_max_old = hf["events"]["fl1_max"][:]
+        fl_offset = min(np.min(hf["events"]["trace"]["fl1_raw"]), 1)
+
+    # Act
+    correct.offset(path_in=path_in, path_out=path_out)
+
+    # Assert
+    with new_dataset(path_out) as ds:
+        assert "baseline 1 offset" in ds.config["fluorescence"]
+        assert ds.config["fluorescence"]["baseline 1 offset"] == fl_offset
+        assert (ds["fl1_max"] == fl_max_old - (fl_offset-1)).all()


### PR DESCRIPTION
This enables the computation of the baseline offset of fluorescence
traces. Including this functionality into the cli-functions enables
users of DCKit to correct the offset of files when applying `compress`,
`join`, `split` or `tdms2rtdc`. This implementation works towards
[DCKit-issue #11.](https://github.com/ZELLMECHANIK-DRESDEN/DCKit/issues/11)