### PR TITLE
Auto-compute other matching Ancillary Feature methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-0.33.3
+0.33.4
  - enh: `AncillaryFeature` now populates other ancillary features when they
-   share the same method (#104).
+   share the same method (#104)
+0.33.3
  - fix: add "chip identifier" to "setup" configuration section and
    make it optional during dataset checks (#109)
  - fix: ignore empty metadata strings (partly #109); removed the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 0.33.3
  - enh: `AncillaryFeature` now populates other ancillary features when they
-   share the same method (#118).
+   share the same method (#104).
  - fix: add "chip identifier" to "setup" configuration section and
    make it optional during dataset checks (#109)
  - fix: ignore empty metadata strings (partly #109); removed the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.33.3
+ - enh: `AncillaryFeature` now populates other ancillary features when they
+   share the same method (#118).
  - fix: add "chip identifier" to "setup" configuration section and
    make it optional during dataset checks (#109)
  - fix: ignore empty metadata strings (partly #109); removed the

--- a/dclab/rtdc_dataset/ancillaries/af_image_contour.py
+++ b/dclab/rtdc_dataset/ancillaries/af_image_contour.py
@@ -24,6 +24,14 @@ def compute_bright_sd(mm):
     return bstd
 
 
+def compute_bright(mm):
+    avg, sd = features.bright.get_bright(mask=mm["mask"],
+                                      image=mm["image"],
+                                      ret_data="avg,sd",
+                                      )
+    return {"bright_avg": avg, "bright_sd": sd}
+
+
 def compute_inert_ratio_cvx(mm):
     return features.inert_ratio.get_inert_ratio_cvx(cont=mm["contour"])
 
@@ -55,11 +63,11 @@ def register():
                      req_features=["mask"])
 
     AncillaryFeature(feature_name="bright_avg",
-                     method=compute_bright_avg,
+                     method=compute_bright,
                      req_features=["image", "mask"])
 
     AncillaryFeature(feature_name="bright_sd",
-                     method=compute_bright_sd,
+                     method=compute_bright,
                      req_features=["image", "mask"])
 
     AncillaryFeature(feature_name="inert_ratio_cvx",

--- a/dclab/rtdc_dataset/ancillaries/af_image_contour.py
+++ b/dclab/rtdc_dataset/ancillaries/af_image_contour.py
@@ -1,6 +1,5 @@
 
 from ... import features
-from ...util import calltracker
 from .ancillary_feature import AncillaryFeature
 
 
@@ -9,7 +8,6 @@ def compute_contour(mm):
     return cont
 
 
-@calltracker
 def compute_bright(mm):
     bavg, bsd = features.bright.get_bright(mask=mm["mask"],
                                            image=mm["image"],

--- a/dclab/rtdc_dataset/ancillaries/af_image_contour.py
+++ b/dclab/rtdc_dataset/ancillaries/af_image_contour.py
@@ -9,29 +9,13 @@ def compute_contour(mm):
     return cont
 
 
-def compute_bright_avg(mm):
-    bavg = features.bright.get_bright(mask=mm["mask"],
-                                      image=mm["image"],
-                                      ret_data="avg",
-                                      )
-    return bavg
-
-
-def compute_bright_sd(mm):
-    bstd = features.bright.get_bright(mask=mm["mask"],
-                                      image=mm["image"],
-                                      ret_data="sd",
-                                      )
-    return bstd
-
-
 @calltracker
 def compute_bright(mm):
-    avg, sd = features.bright.get_bright(mask=mm["mask"],
-                                         image=mm["image"],
-                                         ret_data="avg,sd",
-                                         )
-    return {"bright_avg": avg, "bright_sd": sd}
+    bavg, bsd = features.bright.get_bright(mask=mm["mask"],
+                                           image=mm["image"],
+                                           ret_data="avg,sd",
+                                           )
+    return {"bright_avg": bavg, "bright_sd": bsd}
 
 
 def compute_inert_ratio_cvx(mm):

--- a/dclab/rtdc_dataset/ancillaries/af_image_contour.py
+++ b/dclab/rtdc_dataset/ancillaries/af_image_contour.py
@@ -1,5 +1,6 @@
 
 from ... import features
+from ...util import calltracker
 from .ancillary_feature import AncillaryFeature
 
 
@@ -24,11 +25,12 @@ def compute_bright_sd(mm):
     return bstd
 
 
+@calltracker
 def compute_bright(mm):
     avg, sd = features.bright.get_bright(mask=mm["mask"],
-                                      image=mm["image"],
-                                      ret_data="avg,sd",
-                                      )
+                                         image=mm["image"],
+                                         ret_data="avg,sd",
+                                         )
     return {"bright_avg": avg, "bright_sd": sd}
 
 

--- a/dclab/rtdc_dataset/ancillaries/ancillary_feature.py
+++ b/dclab/rtdc_dataset/ancillaries/ancillary_feature.py
@@ -164,7 +164,6 @@ class AncillaryFeature():
 
         data_dict = self.check_data_size(rtdc_ds, data_dict)
 
-        self.data = data_dict[self.feature_name]
         return data_dict
 
     def check_data_size(self, rtdc_ds, data_dict):

--- a/dclab/rtdc_dataset/ancillaries/ancillary_feature.py
+++ b/dclab/rtdc_dataset/ancillaries/ancillary_feature.py
@@ -145,6 +145,14 @@ class AncillaryFeature():
                 feats.append(ft)
         return feats
 
+    @staticmethod
+    def populate_related_ancill_features(feature, rtdc_ds, cols):
+
+        for name, inst in cols.items():
+            if not feature == inst:
+                if feature.method == inst.method:
+                    _ = inst.compute(rtdc_ds)
+
     def compute(self, rtdc_ds):
         """Compute the feature with self.method
 
@@ -161,6 +169,13 @@ class AncillaryFeature():
         data = self.method(rtdc_ds)
         dsize = len(rtdc_ds) - len(data)
 
+        data = self.check_data_size(rtdc_ds, data, dsize)
+
+        self.data = data
+        return {self.feature_name: self.data}
+
+
+    def check_data_size(self, rtdc_ds, data, dsize):
         if dsize > 0:
             msg = "Growing feature {} in {} by {} to match event number!"
             warnings.warn(msg.format(self.feature_name, rtdc_ds, abs(dsize)),
@@ -179,7 +194,6 @@ class AncillaryFeature():
             for item in data:
                 if isinstance(item, np.ndarray):
                     item.setflags(write=False)
-
         return data
 
     def hash(self, rtdc_ds):

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -100,8 +100,6 @@ class RTDCBase(object):
         ancol = AncillaryFeature.available_features(self)
         if key in ancol:
             # The feature is available.
-            AncillaryFeature.populate_related_ancill_features(
-                ancol[key], self, ancol)
             anhash = ancol[key].hash(self)
             if (key in self._ancillaries and
                     self._ancillaries[key][0] == anhash):
@@ -109,9 +107,11 @@ class RTDCBase(object):
                 data = self._ancillaries[key][1]
             else:
                 # Compute new value
-                data = ancol[key].compute(self)[key]
-                # Store computed value in `self._ancillaries`.
-                self._ancillaries[key] = (anhash, data)
+                data_dict = ancol[key].compute(self)
+                for okey in data_dict:
+                    # Store computed value in `self._ancillaries`.
+                    self._ancillaries[okey] = (anhash, data_dict[okey])
+                data = data_dict[key]
             return data
         else:
             raise KeyError("Feature '{}' does not exist!".format(key))

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -100,6 +100,8 @@ class RTDCBase(object):
         ancol = AncillaryFeature.available_features(self)
         if key in ancol:
             # The feature is available.
+            AncillaryFeature.populate_related_ancill_features(
+                ancol[key], self, ancol)
             anhash = ancol[key].hash(self)
             if (key in self._ancillaries and
                     self._ancillaries[key][0] == anhash):
@@ -107,7 +109,7 @@ class RTDCBase(object):
                 data = self._ancillaries[key][1]
             else:
                 # Compute new value
-                data = ancol[key].compute(self)
+                data = ancol[key].compute(self)[key]
                 # Store computed value in `self._ancillaries`.
                 self._ancillaries[key] = (anhash, data)
             return data

--- a/dclab/util.py
+++ b/dclab/util.py
@@ -73,3 +73,12 @@ def obj2bytes(obj):
     else:
         raise ValueError("No rule to convert object '{}' to string.".
                          format(obj.__class__))
+
+
+def calltracker(func):
+    """ Decorator to track how many times a function is called """
+    def wrapped(*args, **kwargs):
+        wrapped.calls += 1
+        return func(*args, **kwargs)
+    wrapped.calls = 0
+    return wrapped

--- a/dclab/util.py
+++ b/dclab/util.py
@@ -73,12 +73,3 @@ def obj2bytes(obj):
     else:
         raise ValueError("No rule to convert object '{}' to string.".
                          format(obj.__class__))
-
-
-def calltracker(func):
-    """ Decorator to track how many times a function is called """
-    def wrapped(*args, **kwargs):
-        wrapped.calls += 1
-        return func(*args, **kwargs)
-    wrapped.calls = 0
-    return wrapped

--- a/tests/helper_methods.py
+++ b/tests/helper_methods.py
@@ -8,6 +8,15 @@ from dclab.rtdc_dataset import fmt_tdms
 from dclab import definitions as dfn
 
 
+def calltracker(func):
+    """Decorator to track how many times a function is called"""
+    def wrapped(*args, **kwargs):
+        wrapped.calls += 1
+        return func(*args, **kwargs)
+    wrapped.calls = 0
+    return wrapped
+
+
 def example_data_dict(size=100, keys=["area_um", "deform"]):
     """Example dict with which an RTDCBase can be instantiated.
     """

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -98,6 +98,20 @@ def test_af_populate_both_brightness():
         assert af_key in feats
 
 
+def test_if_bright_method_run_twice():
+    """ Use a calltracker wrapper on `compute_bright` to verify it is only
+    called once """
+    from dclab.rtdc_dataset.ancillaries.af_image_contour import (
+        compute_bright as cb)
+    assert cb.calls == 1
+    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
+    _ = ds._events.pop("bright_avg")
+    _ = ds._events.pop("bright_sd")
+    _ = ds["bright_sd"]
+    assert cb.calls == 2
+    assert len(ds._ancillaries) == 3
+
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -1,5 +1,6 @@
 import h5py
 import numpy as np
+from unittest.mock import Mock
 
 import dclab
 
@@ -129,6 +130,23 @@ def test_af_populated_by_shared_method_tdms():
         assert af_key in feats
     # clean up for further tests
     cb.calls = 0
+
+
+def test_af_get_bright_called_only_once(monkeypatch):
+    """Test that `get_bright` is only called once, which is desired when
+    creating ancillary features that share the same pipeline"""
+    def wrapper_on_get_bright(mm):
+        dclab.features.bright.get_bright(
+            mask=mm["mask"], image=mm["image"], ret_data="avg,sd")
+
+    mock_run = Mock()
+    monkeypatch.setattr('dclab.features.bright.get_bright', mock_run)
+
+    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
+    wrapper_on_get_bright(ds)
+
+    mock_run.assert_called_once()
+    mock_run.reset_mock()
 
 
 def test_af_time():

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -1,23 +1,29 @@
 import numpy as np
+import pytest
 
 import dclab
 from dclab.rtdc_dataset.ancillaries import AncillaryFeature
 
-from helper_methods import example_data_dict, retrieve_data, \
-    example_data_sets
+from helper_methods import (
+    example_data_dict, retrieve_data, example_data_sets, calltracker)
 
 
-def calltracker(func):
-    """ Decorator to track how many times a function is called """
-    def wrapped(*args, **kwargs):
-        wrapped.calls += 1
-        return func(*args, **kwargs)
-    wrapped.calls = 0
-    return wrapped
+@pytest.fixture
+def fake_af_cleanup_fixture():
+    """Fixture used to setup and cleanup some fake ancillary features"""
+    # code run before the test
+    af1, af2 = setup_fake_af()
+    # variables yielded (input) to the test, then the test is run
+    yield af1, af2
+    # code run after the test
+    shared_fake_af_method.calls = 0
 
 
 @calltracker
-def example_shared_af_method(rtdc_ds):
+def shared_fake_af_method(rtdc_ds):
+    """An example of an `AncillaryFeature.method` that is used to calculate two
+    different ancillary features.
+    """
     cw = rtdc_ds.config["setup"]["channel width"]
     data_dict = {
         "userdef1": np.arange(1, len(rtdc_ds) + 1) * cw,
@@ -26,36 +32,15 @@ def example_shared_af_method(rtdc_ds):
     return data_dict
 
 
-def setup_fake_af(feature_name1, feature_name2,
-                  path="rtdc_data_hdf5_rtfdc.zip"):
-    af1 = AncillaryFeature(feature_name=feature_name1,
-                           method=example_shared_af_method,
+def setup_fake_af():
+    """Creates some example ancillary features"""
+    af1 = AncillaryFeature(feature_name="userdef1",
+                           method=shared_fake_af_method,
                            req_config=[["setup", ["channel width"]]])
-    af2 = AncillaryFeature(feature_name=feature_name2,
-                           method=example_shared_af_method,
+    af2 = AncillaryFeature(feature_name="userdef2",
+                           method=shared_fake_af_method,
                            req_config=[["setup", ["channel width"]]])
-
-    ds = dclab.new_dataset(retrieve_data(path))
-    assert feature_name1 not in ds.features_innate
-    assert feature_name2 not in ds.features_innate
-    assert feature_name1 in ds
-    assert feature_name2 in ds
-    return ds, af1, af2
-
-
-def cleanup_fake_af(af1, af2, path="rtdc_data_hdf5_rtfdc.zip"):
-    af1_feature_name, af2_feature_name = af1.feature_name, af2.feature_name
-    AncillaryFeature.features.remove(af1)
-    AncillaryFeature.features.remove(af2)
-    AncillaryFeature.feature_names.remove(af1_feature_name)
-    AncillaryFeature.feature_names.remove(af2_feature_name)
-    # make sure cleanup worked
-    ds2 = dclab.new_dataset(retrieve_data(path))
-    assert af1_feature_name not in ds2
-    assert af2_feature_name not in ds2
-    # cleanup the calltracker
-    example_shared_af_method.calls = 0
-
+    return af1, af2
 
 
 def test_af_0basic():
@@ -124,74 +109,62 @@ def test_af_deform():
     assert np.allclose(ds["deform"], 1 - ds["circ"])
 
 
-def test_af_shared_af_method_pipeline_called_once_hdf5():
-    """Uses `setup_cleanup_fake_ancillary_features` as a fixture"""
-    path = "rtdc_data_hdf5_rtfdc.zip"
-    feature_name1, feature_name2 = "userdef1", "userdef2"
-    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
-
-    assert example_shared_af_method.calls == 0
-    assert len(ds._ancillaries) == 0
-
-    _ = ds[feature_name1]
-    assert example_shared_af_method.calls == 1
-    assert len(ds._ancillaries) == 2
-
-    _ = ds[feature_name2]
-    assert example_shared_af_method.calls == 1, "method is not called again"
-    assert len(ds._ancillaries) == 2
-    feats = [feature_name1, feature_name2]
-    for af_key in ds._ancillaries:
-        assert af_key in feats
-    cleanup_fake_af(af1, af2, path)
-
-
-def test_af_shared_af_method_pipeline_called_once_tdms():
-    """Calling ancillary features will automatically populate other features
-    that share the same method.
+@pytest.mark.parametrize("path", example_data_sets)
+def test_af_method_called_once_with_shared_pipeline(
+        fake_af_cleanup_fixture, path):
+    """Verifies that when an `AncillaryFeature.method` is shared between
+    ancillary features, the `method` itself is only called once. All ancillary
+    features that share the `method` will be populated in this single call.
     """
-    path = "rtdc_data_traces_video_bright.zip"
-    feature_name1, feature_name2 = "userdef1", "userdef2"
-    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
+    af1, af2 = fake_af_cleanup_fixture
+    ds = dclab.new_dataset(retrieve_data(path))
+    assert af1.feature_name not in ds.features_innate
+    assert af2.feature_name not in ds.features_innate
+    assert af1.feature_name in ds
+    assert af2.feature_name in ds
 
-    assert example_shared_af_method.calls == 0
-    assert len(ds._ancillaries) == 1  # time is populated
-    # both "bright_avg" and "bright_sd" will be populated by one call
-    _ = ds[feature_name1]
-    assert example_shared_af_method.calls == 1
-    assert len(ds._ancillaries) == 3
+    # handle tdms "time" `AncillaryFeature`
+    tdms_time_feature = False
+    feats = [af1.feature_name, af2.feature_name]
+    if "tdms" in ds.identifier:
+        tdms_time_feature = True
+        feats.append("time")
 
-    _ = ds[feature_name2]
-    assert example_shared_af_method.calls == 1, "method is not called again"
-    assert len(ds._ancillaries) == 3
+    assert shared_fake_af_method.calls == 0
+    assert len(ds._ancillaries) == 0 + tdms_time_feature
 
-    feats = ["time", feature_name1, feature_name2]
-    for af_key in ds._ancillaries:
-        assert af_key in feats
-    cleanup_fake_af(af1, af2, path)
+    _ = ds[af1.feature_name]
+    assert shared_fake_af_method.calls == 1
+    assert len(ds._ancillaries) == 2 + tdms_time_feature
+    assert all(k in ds._ancillaries for k in feats)
+
+    _ = ds[af2.feature_name]
+    assert shared_fake_af_method.calls == 1, "method is not called again"
+    assert len(ds._ancillaries) == 2 + tdms_time_feature
 
 
-def test_af_recomputed_on_hash_change():
-    """Check whether features are recomputed when the hash changes.
-    Uses `setup_cleanup_fake_ancillary_features` as a fixture.
-    """
-    path = "rtdc_data_hdf5_rtfdc.zip"
-    feature_name1, feature_name2 = "userdef1", "userdef2"
-    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
+@pytest.mark.parametrize("path", example_data_sets)
+def test_af_recomputed_on_hash_change(fake_af_cleanup_fixture, path):
+    """Check whether features are recomputed when the hash changes"""
+    af1, af2 = fake_af_cleanup_fixture
+    ds = dclab.new_dataset(retrieve_data(path))
+    assert af1.feature_name not in ds.features_innate
+    assert af2.feature_name not in ds.features_innate
+    assert af1.feature_name in ds
+    assert af2.feature_name in ds
 
-    ud1a = ds[feature_name1]
-    ud2a = ds[feature_name2]
+    ud1a = ds[af1.feature_name]
+    ud2a = ds[af2.feature_name]
 
     ds.config["setup"]["channel width"] *= 1.1
 
-    ud1b = ds[feature_name1]
-    ud2b = ds[feature_name2]
+    ud1b = ds[af1.feature_name]
+    ud2b = ds[af2.feature_name]
 
     assert np.all(ud1a != ud1b)
     assert np.allclose(ud1a * 1.1, ud1b)
     assert np.all(ud2a != ud2b)
     assert np.allclose(ud2a * 1.1, ud2b)
-    cleanup_fake_af(af1, af2, path)
 
 
 def test_af_time():
@@ -200,32 +173,6 @@ def test_af_time():
     assert tt[0] == 0
     assert np.allclose(tt[1], 0.0385)
     assert np.all(np.diff(tt) > 0)
-
-
-# def test_af_mock_with_patch(monkeypatch):
-
-    # def calltracker(func):
-    #     """ Decorator to track how many times a function is called """
-    #     def wrap_mock():
-    #         mock_run = Mock()
-    #         return mock_run
-    #     return wrap_mock
-
-    # old_get_bright = dclab.features.bright.get_bright
-
-    # @calltracker
-    # def wrapper_get_bright(mm):
-    #     old_get_bright(mask=mm["mask"], image=mm["image"], ret_data="avg,sd")
-    # mock_run = Mock()
-    # monkeypatch.setattr(
-    #     'dclab.rtdc_dataset.core.RTDCBase.__getitem__.compute', mock_run)
-    #
-    # ds = dclab.new_dataset(retrieve_data(
-    #     "rtdc_data_traces_video_bright.zip"))
-    # _ = ds["bright_sd"]
-    # # _ = ds["bright_avg"]
-    # mock_run.assert_called_once()
-    # mock_run.reset_mock()
 
 
 if __name__ == "__main__":

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -82,8 +82,9 @@ def test_af_time():
 
 
 def test_af_populated_by_shared_method_tdms():
-    """ Calling ancillary features will automatically populate other features
-    that share methods. """
+    """Calling ancillary features will automatically populate other features
+    that share the same method.
+    """
     from dclab.rtdc_dataset.ancillaries.af_image_contour import (
         compute_bright as cb)
     cb.calls = 0
@@ -109,8 +110,9 @@ def test_af_populated_by_shared_method_tdms():
 
 
 def test_af_populated_by_shared_method_hdf5():
-    """ Calling ancillary features will automatically populate other features
-    that share methods. """
+    """Calling ancillary features will automatically populate other features
+    that share the same method.
+    """
     from dclab.rtdc_dataset.ancillaries.af_image_contour import (
         compute_bright as cb)
     cb.calls = 0

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -126,7 +126,7 @@ def test_af_method_called_once_with_shared_pipeline(
     # handle tdms "time" `AncillaryFeature`
     tdms_time_feature = False
     feats = [af1.feature_name, af2.feature_name]
-    if "tdms" in ds.identifier:
+    if ds.format == "tdms":
         tdms_time_feature = True
         feats.append("time")
 

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -84,6 +84,9 @@ def test_af_time():
 def test_af_populated_by_shared_method_tdms():
     """ Calling ancillary features will automatically populate other features
     that share methods. """
+    from dclab.rtdc_dataset.ancillaries.af_image_contour import (
+        compute_bright as cb)
+    cb.calls = 0
     ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
     # This is something low-level and should not be done in a script.
     # Remove the brightness columns from RTDCBase to force computation with
@@ -92,18 +95,25 @@ def test_af_populated_by_shared_method_tdms():
     _ = ds._events.pop("bright_sd")
     assert "bright_avg" not in ds.features_innate
     assert "bright_sd" not in ds.features_innate
+    assert cb.calls == 0
     assert len(ds._ancillaries) == 1  # time is populated
     _ = ds["bright_avg"]
-    # both "bright_avg" and "bright_sd" will be populated
+    # both "bright_avg" and "bright_sd" will be populated by one call
+    assert cb.calls == 1
     assert len(ds._ancillaries) == 3
     feats = ["time", "bright_sd", "bright_avg"]
     for af_key in ds._ancillaries:
         assert af_key in feats
+    # clean up for furthur tests
+    cb.calls = 0
 
 
 def test_af_populated_by_shared_method_hdf5():
     """ Calling ancillary features will automatically populate other features
     that share methods. """
+    from dclab.rtdc_dataset.ancillaries.af_image_contour import (
+        compute_bright as cb)
+    cb.calls = 0
     path = retrieve_data("rtdc_data_hdf5_rtfdc.zip")
     with h5py.File(path, "r+") as h5:
         _ = h5["events"]["bright_avg"][:]
@@ -114,29 +124,17 @@ def test_af_populated_by_shared_method_hdf5():
     # sanity checks
     assert "bright_avg" not in ds.features_innate
     assert "bright_sd" not in ds.features_innate
+    assert cb.calls == 0
     assert len(ds._ancillaries) == 0
     _ = ds["bright_avg"]
-    # both "bright_avg" and "bright_sd" will be populated
+    # both "bright_avg" and "bright_sd" will be populated by one call
+    assert cb.calls == 1
     assert len(ds._ancillaries) == 2
     feats = ["bright_sd", "bright_avg"]
     for af_key in ds._ancillaries:
         assert af_key in feats
-
-
-def test_shared_method_only_run_once():
-    """ Use a calltracker wrapper on `compute_bright` to verify it is only
-    called once """
-    from dclab.rtdc_dataset.ancillaries.af_image_contour import (
-        compute_bright as cb)
+    # clean up for furthur tests
     cb.calls = 0
-    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
-    _ = ds._events.pop("bright_avg")
-    _ = ds._events.pop("bright_sd")
-    assert len(ds._ancillaries) == 1  # time is populated
-    assert cb.calls == 0
-    _ = ds["bright_sd"]
-    assert cb.calls == 1
-    assert len(ds._ancillaries) == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -34,7 +34,7 @@ def setup_fake_af(feature_name1, feature_name2,
     af2 = AncillaryFeature(feature_name=feature_name2,
                            method=example_shared_af_method,
                            req_config=[["setup", ["channel width"]]])
-    example_shared_af_method.calls = 0
+
     ds = dclab.new_dataset(retrieve_data(path))
     assert feature_name1 not in ds.features_innate
     assert feature_name2 not in ds.features_innate
@@ -53,6 +53,9 @@ def cleanup_fake_af(af1, af2, path="rtdc_data_hdf5_rtfdc.zip"):
     ds2 = dclab.new_dataset(retrieve_data(path))
     assert af1_feature_name not in ds2
     assert af2_feature_name not in ds2
+    # cleanup the calltracker
+    example_shared_af_method.calls = 0
+
 
 
 def test_af_0basic():

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -12,11 +12,20 @@ from helper_methods import (
 def fake_af_cleanup_fixture():
     """Fixture used to setup and cleanup some fake ancillary features"""
     # code run before the test
+    # set the method calls of our shared method to zero (just in case)
+    shared_fake_af_method.calls = 0
+    # setup fake ancillary features
     af1, af2 = setup_fake_af()
     # variables yielded (input) to the test, then the test is run
     yield af1, af2
     # code run after the test
+    # set the method calls of our shared method to zero
     shared_fake_af_method.calls = 0
+    # remove our fake ancillary feature instances from the registry
+    AncillaryFeature.features.remove(af1)
+    AncillaryFeature.features.remove(af2)
+    AncillaryFeature.feature_names.remove(af1.feature_name)
+    AncillaryFeature.feature_names.remove(af2.feature_name)
 
 
 @calltracker

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -80,6 +80,24 @@ def test_af_time():
     assert np.all(np.diff(tt) > 0)
 
 
+def test_af_populate_both_brightness():
+    """ Calling ancillary features will automatically populate other features
+    that share methods. """
+    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
+    assert len(ds._ancillaries) == 1  # time is populated
+    # This is something low-level and should not be done in a script.
+    # Remove the brightness columns from RTDCBase to force computation with
+    # the image and contour columns.
+    _ = ds._events.pop("bright_avg")
+    _ = ds._events.pop("bright_sd")
+    _ = ds["bright_avg"]
+    # both "bright_avg" and "bright_sd" will be populated
+    assert len(ds._ancillaries) == 3
+    feats = ["time", "bright_sd", "bright_avg"]
+    for af_key in ds._ancillaries:
+        assert af_key in feats
+
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -1,12 +1,58 @@
-import h5py
 import numpy as np
-from unittest.mock import Mock
 
 import dclab
 from dclab.rtdc_dataset.ancillaries import AncillaryFeature
 
 from helper_methods import example_data_dict, retrieve_data, \
     example_data_sets
+
+
+def calltracker(func):
+    """ Decorator to track how many times a function is called """
+    def wrapped(*args, **kwargs):
+        wrapped.calls += 1
+        return func(*args, **kwargs)
+    wrapped.calls = 0
+    return wrapped
+
+
+@calltracker
+def example_shared_af_method(rtdc_ds):
+    cw = rtdc_ds.config["setup"]["channel width"]
+    data_dict = {
+        "userdef1": np.arange(1, len(rtdc_ds) + 1) * cw,
+        "userdef2": np.arange(1, len(rtdc_ds) + 1) * cw * 2
+    }
+    return data_dict
+
+
+def setup_fake_af(feature_name1, feature_name2,
+                  path="rtdc_data_hdf5_rtfdc.zip"):
+    af1 = AncillaryFeature(feature_name=feature_name1,
+                           method=example_shared_af_method,
+                           req_config=[["setup", ["channel width"]]])
+    af2 = AncillaryFeature(feature_name=feature_name2,
+                           method=example_shared_af_method,
+                           req_config=[["setup", ["channel width"]]])
+    example_shared_af_method.calls = 0
+    ds = dclab.new_dataset(retrieve_data(path))
+    assert feature_name1 not in ds.features_innate
+    assert feature_name2 not in ds.features_innate
+    assert feature_name1 in ds
+    assert feature_name2 in ds
+    return ds, af1, af2
+
+
+def cleanup_fake_af(af1, af2, path="rtdc_data_hdf5_rtfdc.zip"):
+    af1_feature_name, af2_feature_name = af1.feature_name, af2.feature_name
+    AncillaryFeature.features.remove(af1)
+    AncillaryFeature.features.remove(af2)
+    AncillaryFeature.feature_names.remove(af1_feature_name)
+    AncillaryFeature.feature_names.remove(af2_feature_name)
+    # make sure cleanup worked
+    ds2 = dclab.new_dataset(retrieve_data(path))
+    assert af1_feature_name not in ds2
+    assert af2_feature_name not in ds2
 
 
 def test_af_0basic():
@@ -75,113 +121,74 @@ def test_af_deform():
     assert np.allclose(ds["deform"], 1 - ds["circ"])
 
 
-def test_af_get_bright_called_only_once(monkeypatch):
-    """Test that `get_bright` is only called once, which is desired when
-    creating ancillary features that share the same pipeline"""
-    def wrapper_on_get_bright(mm):
-        dclab.features.bright.get_bright(
-            mask=mm["mask"], image=mm["image"], ret_data="avg,sd")
+def test_af_shared_af_method_pipeline_called_once_hdf5():
+    """Uses `setup_cleanup_fake_ancillary_features` as a fixture"""
+    path = "rtdc_data_hdf5_rtfdc.zip"
+    feature_name1, feature_name2 = "userdef1", "userdef2"
+    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
 
-    mock_run = Mock()
-    monkeypatch.setattr('dclab.features.bright.get_bright', mock_run)
-
-    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
-    wrapper_on_get_bright(ds)
-
-    mock_run.assert_called_once()
-    mock_run.reset_mock()
-
-
-def test_af_populated_by_shared_method_hdf5():
-    """Calling ancillary features will automatically populate other features
-    that share the same method.
-    """
-    path = retrieve_data("rtdc_data_hdf5_rtfdc.zip")
-    with h5py.File(path, "r+") as h5:
-        del h5["events"]["bright_avg"]
-        del h5["events"]["bright_sd"]
-    ds = dclab.new_dataset(path)
-    # sanity checks
-    assert "bright_avg" not in ds.features_innate
-    assert "bright_sd" not in ds.features_innate
+    assert example_shared_af_method.calls == 0
     assert len(ds._ancillaries) == 0
 
-    # both "bright_avg" and "bright_sd" will be populated by one call
-    _ = ds["bright_avg"]
+    _ = ds[feature_name1]
+    assert example_shared_af_method.calls == 1
     assert len(ds._ancillaries) == 2
-    feats = ["bright_sd", "bright_avg"]
+
+    _ = ds[feature_name2]
+    assert example_shared_af_method.calls == 1, "method is not called again"
+    assert len(ds._ancillaries) == 2
+    feats = [feature_name1, feature_name2]
     for af_key in ds._ancillaries:
         assert af_key in feats
+    cleanup_fake_af(af1, af2, path)
 
 
-def test_af_populated_by_shared_method_tdms():
+def test_af_shared_af_method_pipeline_called_once_tdms():
     """Calling ancillary features will automatically populate other features
     that share the same method.
     """
-    ds = dclab.new_dataset(retrieve_data("rtdc_data_traces_video_bright.zip"))
-    # This is something low-level and should not be done in a script.
-    # Remove the brightness columns from RTDCBase to force computation with
-    # the image and contour columns.
-    _ = ds._events.pop("bright_avg")
-    _ = ds._events.pop("bright_sd")
-    assert "bright_avg" not in ds.features_innate
-    assert "bright_sd" not in ds.features_innate
-    assert len(ds._ancillaries) == 1  # time is populated
+    path = "rtdc_data_traces_video_bright.zip"
+    feature_name1, feature_name2 = "userdef1", "userdef2"
+    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
 
+    assert example_shared_af_method.calls == 0
+    assert len(ds._ancillaries) == 1  # time is populated
     # both "bright_avg" and "bright_sd" will be populated by one call
-    _ = ds["bright_avg"]
+    _ = ds[feature_name1]
+    assert example_shared_af_method.calls == 1
     assert len(ds._ancillaries) == 3
-    feats = ["time", "bright_sd", "bright_avg"]
+
+    _ = ds[feature_name2]
+    assert example_shared_af_method.calls == 1, "method is not called again"
+    assert len(ds._ancillaries) == 3
+
+    feats = ["time", feature_name1, feature_name2]
     for af_key in ds._ancillaries:
         assert af_key in feats
+    cleanup_fake_af(af1, af2, path)
 
 
 def test_af_recomputed_on_hash_change():
-    """Check whether features are recomputed when the hash changes"""
-    def method(rtdc_ds):
-        cw = rtdc_ds.config["setup"]["channel width"]
-        data_dict = {
-            "userdef1": np.arange(1, len(rtdc_ds) + 1) * cw,
-            "userdef2": np.arange(1, len(rtdc_ds) + 1) * cw * 2
-        }
-        return data_dict
+    """Check whether features are recomputed when the hash changes.
+    Uses `setup_cleanup_fake_ancillary_features` as a fixture.
+    """
+    path = "rtdc_data_hdf5_rtfdc.zip"
+    feature_name1, feature_name2 = "userdef1", "userdef2"
+    ds, af1, af2 = setup_fake_af(feature_name1, feature_name2, path)
 
-    af1 = AncillaryFeature(feature_name="userdef1",
-                           method=method,
-                           req_config=[["setup", ["channel width"]]])
-    af2 = AncillaryFeature(feature_name="userdef2",
-                           method=method,
-                           req_config=[["setup", ["channel width"]]])
-
-    ds = dclab.new_dataset(retrieve_data("rtdc_data_hdf5_rtfdc.zip"))
-    assert "userdef1" not in ds.features_innate
-    assert "userdef2" not in ds.features_innate
-    assert "userdef1" in ds
-    assert "userdef2" in ds
-
-    ud1a = ds["userdef1"]
-    ud2a = ds["userdef2"]
+    ud1a = ds[feature_name1]
+    ud2a = ds[feature_name2]
 
     ds.config["setup"]["channel width"] *= 1.1
 
-    ud1b = ds["userdef1"]
-    ud2b = ds["userdef2"]
+    ud1b = ds[feature_name1]
+    ud2b = ds[feature_name2]
 
     assert np.all(ud1a != ud1b)
     assert np.allclose(ud1a * 1.1, ud1b)
     assert np.all(ud2a != ud2b)
     assert np.allclose(ud2a * 1.1, ud2b)
-
-    # cleanup
-    AncillaryFeature.features.remove(af1)
-    AncillaryFeature.features.remove(af2)
-    AncillaryFeature.feature_names.remove("userdef1")
-    AncillaryFeature.feature_names.remove("userdef2")
-
-    # make sure cleanup worked
-    ds2 = dclab.new_dataset(retrieve_data("rtdc_data_hdf5_rtfdc.zip"))
-    assert "userdef1" not in ds2
-    assert "userdef2" not in ds2
+    cleanup_fake_af(af1, af2, path)
 
 
 def test_af_time():
@@ -190,6 +197,32 @@ def test_af_time():
     assert tt[0] == 0
     assert np.allclose(tt[1], 0.0385)
     assert np.all(np.diff(tt) > 0)
+
+
+# def test_af_mock_with_patch(monkeypatch):
+
+    # def calltracker(func):
+    #     """ Decorator to track how many times a function is called """
+    #     def wrap_mock():
+    #         mock_run = Mock()
+    #         return mock_run
+    #     return wrap_mock
+
+    # old_get_bright = dclab.features.bright.get_bright
+
+    # @calltracker
+    # def wrapper_get_bright(mm):
+    #     old_get_bright(mask=mm["mask"], image=mm["image"], ret_data="avg,sd")
+    # mock_run = Mock()
+    # monkeypatch.setattr(
+    #     'dclab.rtdc_dataset.core.RTDCBase.__getitem__.compute', mock_run)
+    #
+    # ds = dclab.new_dataset(retrieve_data(
+    #     "rtdc_data_traces_video_bright.zip"))
+    # _ = ds["bright_sd"]
+    # # _ = ds["bright_avg"]
+    # mock_run.assert_called_once()
+    # mock_run.reset_mock()
 
 
 if __name__ == "__main__":

--- a/tests/test_ancillaries.py
+++ b/tests/test_ancillaries.py
@@ -104,7 +104,7 @@ def test_af_populated_by_shared_method_tdms():
     feats = ["time", "bright_sd", "bright_avg"]
     for af_key in ds._ancillaries:
         assert af_key in feats
-    # clean up for furthur tests
+    # clean up for further tests
     cb.calls = 0
 
 
@@ -133,7 +133,7 @@ def test_af_populated_by_shared_method_hdf5():
     feats = ["bright_sd", "bright_avg"]
     for af_key in ds._ancillaries:
         assert af_key in feats
-    # clean up for furthur tests
+    # clean up for further tests
     cb.calls = 0
 
 

--- a/tests/test_feat_bright.py
+++ b/tests/test_feat_bright.py
@@ -5,7 +5,7 @@ import dclab
 from dclab import new_dataset
 from dclab.features.bright import get_bright
 
-from helper_methods import retrieve_data
+from helper_methods import calltracker, retrieve_data
 
 
 def test_af_brightness():
@@ -26,6 +26,35 @@ def test_af_brightness():
     idcompare[0] = False
     assert np.allclose(real_avg[idcompare], comp_avg[idcompare])
     assert np.allclose(real_sd[idcompare], comp_sd[idcompare])
+
+
+def test_af_brightness_called_once(monkeypatch):
+    """Make sure dclab.features.bright.get_bright is only called once"""
+    path = retrieve_data("rtdc_data_hdf5_image_bg.zip")
+    # remove brightness features
+    with h5py.File(path, "r+") as h5:
+        del h5["events"]["bright_avg"]
+        del h5["events"]["bright_sd"]
+
+    # wrap the original brightness retrieval function
+    old_get_bright = dclab.features.bright.get_bright
+
+    @calltracker
+    def wrap_get_bright(*args, **kwargs):
+        return old_get_bright(*args, **kwargs)
+    # Monkeypatch the imported function used in the ancillaries submodule,
+    # otherwise (dclab.features.bright.get_bright) it is not called.
+    monkeypatch.setattr("dclab.rtdc_dataset.ancillaries.af_image_contour"
+                        ".features.bright.get_bright",
+                        wrap_get_bright)
+
+    # assert (access both brightness features and make sure that the
+    # original function is only called once)
+    ds = dclab.new_dataset(path)
+    ds["bright_sd"]
+    ds["bright_avg"]
+
+    assert wrap_get_bright.calls == 1
 
 
 def test_simple_bright():

--- a/tests/test_feat_bright.py
+++ b/tests/test_feat_bright.py
@@ -51,8 +51,8 @@ def test_af_brightness_called_once(monkeypatch):
     # assert (access both brightness features and make sure that the
     # original function is only called once)
     ds = dclab.new_dataset(path)
-    ds["bright_sd"]
-    ds["bright_avg"]
+    _ = ds["bright_sd"]
+    _ = ds["bright_avg"]
 
     assert wrap_get_bright.calls == 1
 

--- a/tests/test_feat_bright.py
+++ b/tests/test_feat_bright.py
@@ -41,6 +41,11 @@ def test_simple_bright():
         avg, std = get_bright(mask=mask, image=image, ret_data="avg,sd")
         assert np.allclose(avg, ds["bright_avg"][ii])
         assert np.allclose(std, ds["bright_sd"][ii])
+        # cover single `ret_data` input
+        assert np.allclose(
+            avg, get_bright(mask=mask, image=image, ret_data="avg"))
+        assert np.allclose(
+            std, get_bright(mask=mask, image=image, ret_data="sd"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here I am attempting to implement the changes desired in #104.

A few questions/comments:

- Is it reasonable to perform the check between the called `AncillaryFeature` method and all other possible methods in `RTDCBASE.__getitem__`? The check is performed in `populate_related_ancill_features` and is a static method in the `AncillaryFeature` class.
- If the above approach is good, then I guess we don't need `AncillaryFeature.compute` to return a dict (`{self.feature_name: self.data}`), right?
- The `AncillaryFeature.clean_data_size` method doesn't have to stay, just wanted to make things clearer for myself.
- These changes cause some of the ML score tests to fail. I don't exactly understand why this behaviour has changed.

If I'm way off the mark, let me know.