### PR TITLE
fix: slicing of non-scalar features for hierarchy childs (#128)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.34.2
+ - fix: slicing of non-scalar features for hierarchy childs (#128)
  - fix: passing a directory to the CLI tdms2rtdc did not work
  - ref: cleanup CLI code
  - tests: increase coverage of CLI (#116)

--- a/dclab/rtdc_dataset/fmt_hdf5.py
+++ b/dclab/rtdc_dataset/fmt_hdf5.py
@@ -43,7 +43,12 @@ class H5ContourEvent(object):
         self.identifier = h5group["0"][:]
 
     def __getitem__(self, key):
-        return self.h5group[str(key)][:]
+        if isinstance(key, (int, np.integer)) and key >= 0:
+            return self.h5group[str(key)][:]
+        else:
+            raise NotImplementedError(
+                    "The feature `contour` only supports positive"
+                    "integer indexing!")
 
     def __iter__(self):
         for idx in range(len(self)):

--- a/dclab/rtdc_dataset/fmt_hdf5.py
+++ b/dclab/rtdc_dataset/fmt_hdf5.py
@@ -47,7 +47,7 @@ class H5ContourEvent(object):
             return self.h5group[str(key)][:]
         else:
             raise NotImplementedError(
-                    "The feature `contour` only supports positive"
+                    "The feature `contour` only supports positive "
                     "integer indexing!")
 
     def __iter__(self):

--- a/dclab/rtdc_dataset/fmt_hierarchy.py
+++ b/dclab/rtdc_dataset/fmt_hierarchy.py
@@ -27,7 +27,7 @@ class ChildBase(object):
 class ChildContour(ChildBase):
     def __getitem__(self, idx):
         pidx = map_indices_child2parent(child=self.child,
-                                        child_indices=[idx])[0]
+                                        child_indices=idx)
         hp = self.child.hparent
         return hp["contour"][pidx]
 
@@ -35,7 +35,7 @@ class ChildContour(ChildBase):
 class ChildImage(ChildBase):
     def __getitem__(self, idx):
         pidx = map_indices_child2parent(child=self.child,
-                                        child_indices=[idx])[0]
+                                        child_indices=idx)
         hp = self.child.hparent
         return hp["image"][pidx]
 
@@ -43,7 +43,7 @@ class ChildImage(ChildBase):
 class ChildImageBG(ChildBase):
     def __getitem__(self, idx):
         pidx = map_indices_child2parent(child=self.child,
-                                        child_indices=[idx])[0]
+                                        child_indices=idx)
         hp = self.child.hparent
         return hp["image_bg"][pidx]
 
@@ -51,7 +51,7 @@ class ChildImageBG(ChildBase):
 class ChildMask(ChildBase):
     def __getitem__(self, idx):
         pidx = map_indices_child2parent(child=self.child,
-                                        child_indices=[idx])[0]
+                                        child_indices=idx)
         hp = self.child.hparent
         return hp["mask"][pidx]
 
@@ -63,7 +63,7 @@ class ChildTrace(ChildBase):
 
     def __getitem__(self, idx):
         pidx = map_indices_child2parent(child=self.child,
-                                        child_indices=[idx])[0]
+                                        child_indices=idx)
         hp = self.child.hparent
         return hp["trace"][self.flname][pidx]
 

--- a/tests/test_rtdc_fmt_hdf5.py
+++ b/tests/test_rtdc_fmt_hdf5.py
@@ -120,6 +120,19 @@ def test_image_bg_2():
         assert bgc[10, 11] == 6
 
 
+@pytest.mark.filterwarnings(
+    'ignore::dclab.rtdc_dataset.config.UnknownConfigurationKeyWarning')
+@pytest.mark.parametrize("idxs",
+                         [slice(1, 4), -1, [1, 2, 3], np.arange(3), 5*[True]])
+def test_index_slicing_contour(idxs):
+    data = retrieve_data("rtdc_data_hdf5_contour_image_trace.zip")
+    ds = new_dataset(data)
+
+    with pytest.raises(NotImplementedError,
+                       match="only supports positive integer indexing"):
+        ds["contour"][idxs]
+
+
 def test_logs():
     path_in = retrieve_data("rtdc_data_hdf5_mask_contour.zip")
 

--- a/tests/test_rtdc_fmt_hierarchy.py
+++ b/tests/test_rtdc_fmt_hierarchy.py
@@ -158,6 +158,37 @@ def test_index_deep_contour():
     assert np.all(c2["contour"][3] == ds["contour"][5])
 
 
+@pytest.mark.parametrize("feat", ["image", "image_bg", "mask"])
+def test_index_slicing(feat):
+    data = retrieve_data("rtdc_data_hdf5_image_bg.zip")
+    ds = new_dataset(data)
+    ds.filter.manual[2] = False
+    ch = new_dataset(ds)
+
+    ds_feat = ds[feat][np.array([0, 1, 3])]
+    ch_feat = ch[feat]
+
+    assert np.all(ch_feat[:3] == ds_feat)
+    assert np.all(ch_feat[np.arange(0, 3)] == ds_feat)
+    assert np.all(ch_feat[[0, 1, 2]] == ds_feat)
+    assert np.all(ch_feat[np.array([True, True, True, False])] == ds_feat)
+
+
+def test_index_slicing_trace():
+    data = retrieve_data("rtdc_data_hdf5_contour_image_trace.zip")
+    ds = new_dataset(data)
+    ds.filter.manual[2] = False
+    ch = new_dataset(ds)
+
+    ds_feat = ds["trace"]["fl1_median"][np.array([0, 1, 3])]
+    ch_feat = ch["trace"]["fl1_median"]
+
+    assert np.all(ch_feat[:3] == ds_feat)
+    assert np.all(ch_feat[np.arange(0, 3)] == ds_feat)
+    assert np.all(ch_feat[[0, 1, 2]] == ds_feat)
+    assert np.all(ch_feat[np.array([True, True, True, False])] == ds_feat)
+
+
 def test_manual_exclude():
     data = example_data_dict(42, keys=["area_um", "deform"])
     p = new_dataset(data)

--- a/tests/test_rtdc_fmt_hierarchy.py
+++ b/tests/test_rtdc_fmt_hierarchy.py
@@ -159,7 +159,9 @@ def test_index_deep_contour():
 
 
 @pytest.mark.parametrize("feat", ["image", "image_bg", "mask"])
-def test_index_slicing(feat):
+@pytest.mark.parametrize("idxs", [slice(0, 3), np.arange(3),
+                                  [0, 1, 2], [True, True, True, False]])
+def test_index_slicing(feat, idxs):
     data = retrieve_data("rtdc_data_hdf5_image_bg.zip")
     ds = new_dataset(data)
     ds.filter.manual[2] = False
@@ -168,13 +170,14 @@ def test_index_slicing(feat):
     ds_feat = ds[feat][np.array([0, 1, 3])]
     ch_feat = ch[feat]
 
-    assert np.all(ch_feat[:3] == ds_feat)
-    assert np.all(ch_feat[np.arange(0, 3)] == ds_feat)
-    assert np.all(ch_feat[[0, 1, 2]] == ds_feat)
-    assert np.all(ch_feat[np.array([True, True, True, False])] == ds_feat)
+    assert np.all(ch_feat[idxs] == ds_feat)
 
 
-def test_index_slicing_trace():
+@pytest.mark.filterwarnings(
+    'ignore::dclab.rtdc_dataset.config.UnknownConfigurationKeyWarning')
+@pytest.mark.parametrize("idxs", [slice(0, 3), np.arange(3),
+                                  [0, 1, 2], [True, True, True, False]])
+def test_index_slicing_trace(idxs):
     data = retrieve_data("rtdc_data_hdf5_contour_image_trace.zip")
     ds = new_dataset(data)
     ds.filter.manual[2] = False
@@ -183,10 +186,7 @@ def test_index_slicing_trace():
     ds_feat = ds["trace"]["fl1_median"][np.array([0, 1, 3])]
     ch_feat = ch["trace"]["fl1_median"]
 
-    assert np.all(ch_feat[:3] == ds_feat)
-    assert np.all(ch_feat[np.arange(0, 3)] == ds_feat)
-    assert np.all(ch_feat[[0, 1, 2]] == ds_feat)
-    assert np.all(ch_feat[np.array([True, True, True, False])] == ds_feat)
+    assert np.all(ch_feat[idxs] == ds_feat)
 
 
 def test_manual_exclude():


### PR DESCRIPTION
This commit enables slicing on non-scalar features `mask`, `image`,
`image_bg` and `trace` for hierarchy childs (fixes #128).