### PR TITLE
Non scalar Plugin Feature test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,9 @@
    size of ancillary features
  - fix: dclab-split did not work when nptdms is not installed
  - tests: skip tests that require nptdms, requests, or rpy2 if those
+ - enh: add check to warn users from setting None-type config values
    pacakages are not installed
+ - tests: add test for non-scalar plugin feature
  - ci: run tests with different setup.py-extras installed
 0.34.4
  - fix: use temporary file names during CLI operations

--- a/dclab/rtdc_dataset/config.py
+++ b/dclab/rtdc_dataset/config.py
@@ -20,6 +20,9 @@ class BadUserConfigurationKeyWarning(UserWarning):
     pass
 
 
+class BadUserConfigurationValueWarning(UserWarning):
+    pass
+
 class ConfigurationDict(dict):
     def __init__(self, section=None, *args, **kwargs):
         """A case-insensitive dict that is section-aware
@@ -51,6 +54,12 @@ class ConfigurationDict(dict):
                 valid = False
         else:
             valid = True
+        if value is None:
+            warnings.warn(
+                f"Bad value '{value}' for [{self.section}]: '{key}'!",
+                BadUserConfigurationValueWarning,
+            )
+            valid = False
         if valid:
             # only set valid keys
             super(ConfigurationDict, self).__setitem__(key, value)

--- a/dclab/rtdc_dataset/config.py
+++ b/dclab/rtdc_dataset/config.py
@@ -23,6 +23,7 @@ class BadUserConfigurationKeyWarning(UserWarning):
 class BadUserConfigurationValueWarning(UserWarning):
     pass
 
+
 class ConfigurationDict(dict):
     def __init__(self, section=None, *args, **kwargs):
         """A case-insensitive dict that is section-aware

--- a/dclab/rtdc_dataset/filter.py
+++ b/dclab/rtdc_dataset/filter.py
@@ -113,11 +113,9 @@ class Filter(object):
 
         # Determine which data was updated
         for skey in list(cfg_cur.keys()):
-            if skey not in cfg_old:
-                cfg_old[skey] = 'none'
-            if cfg_cur[skey] != cfg_old[skey]:
+            if cfg_cur[skey] != cfg_old.get(skey, None):
                 newkeys.append(skey)
-                oldvals.append(cfg_old[skey])
+                oldvals.append(cfg_old.get(skey, None))
                 newvals.append(cfg_cur[skey])
 
         # 1. Invalid filters

--- a/dclab/rtdc_dataset/filter.py
+++ b/dclab/rtdc_dataset/filter.py
@@ -114,7 +114,7 @@ class Filter(object):
         # Determine which data was updated
         for skey in list(cfg_cur.keys()):
             if skey not in cfg_old:
-                cfg_old[skey] = None
+                cfg_old[skey] = 'none'
             if cfg_cur[skey] != cfg_old[skey]:
                 newkeys.append(skey)
                 oldvals.append(cfg_old[skey])

--- a/tests/test_rtdc_config.py
+++ b/tests/test_rtdc_config.py
@@ -267,6 +267,21 @@ def test_user_section_set_save_reload_fmt_dcor():
         assert ds2.config["user"] == metadata
 
 
+def test_user_section_set_save_reload_fmt_hdf5_bad_values():
+    """Check that NoneType is not allowed for HDF5"""
+    h5path = retrieve_data("rtdc_data_hdf5_rtfdc.zip")
+    # None is not allowed by hdf5
+    metadata = {"channel area": None,
+                "inlet": True,
+                "n_constrictions": 3,
+                "channel information": "other information"}
+    with new_dataset(h5path) as ds:
+        ds.config.update({"user": metadata})
+        expath = h5path.with_name("exported.rtdc")
+        with pytest.raises(TypeError):
+            ds.export.hdf5(expath, features=ds.features_innate)
+
+
 def test_user_section_set_save_reload_fmt_hdf5_basic():
     """Check that 'user' section metadata works for RTDC_HDF5"""
     h5path = retrieve_data("rtdc_data_hdf5_rtfdc.zip")

--- a/tests/test_rtdc_config.py
+++ b/tests/test_rtdc_config.py
@@ -104,6 +104,8 @@ def test_user_section_allowed_key_types():
         ds.config["user"][[5, 12.3, False, "a word"]] = "a word"
     with pytest.warns(dccfg.BadUserConfigurationKeyWarning):
         ds.config["user"][{"name": 12.3, False: "a word"}] = "a word"
+    with pytest.warns(dccfg.BadUserConfigurationValueWarning):
+        ds.config["user"]["name"] = None
 
     assert len(ds.config["user"]) == 1
     assert isinstance(ds.config["user"]["a string"], str)
@@ -265,21 +267,6 @@ def test_user_section_set_save_reload_fmt_dcor():
     # check it again with dclab
     with new_dataset(expath) as ds2:
         assert ds2.config["user"] == metadata
-
-
-def test_user_section_set_save_reload_fmt_hdf5_bad_values():
-    """Check that NoneType is not allowed for HDF5"""
-    h5path = retrieve_data("rtdc_data_hdf5_rtfdc.zip")
-    # None is not allowed by hdf5
-    metadata = {"channel area": None,
-                "inlet": True,
-                "n_constrictions": 3,
-                "channel information": "other information"}
-    with new_dataset(h5path) as ds:
-        ds.config.update({"user": metadata})
-        expath = h5path.with_name("exported.rtdc")
-        with pytest.raises(TypeError):
-            ds.export.hdf5(expath, features=ds.features_innate)
 
 
 def test_user_section_set_save_reload_fmt_hdf5_basic():


### PR DESCRIPTION
Two things I noticed were lacking from the tests.
- [x] `NoneType` user config section values are not allowed (because they can't be saved by HDF5.
- [x] Added a test for a non-scalar Plugin Feature.
