### PR TITLE
fix: enable loading of non-scalar plugin data as h5py.Dataset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-0.39.13
+0.39.14
  - fix: enable loading of non-scalar plugin data as h5py.Dataset (#162)
+0.39.13
  - fix: recompute the "ml_class" feature if the ml_score features
    change (either the underlying model or the number of features)
 0.39.12

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.39.13
+ - fix: enable loading of non-scalar plugin data as h5py.Dataset (#162)
  - fix: recompute the "ml_class" feature if the ml_score features
    change (either the underlying model or the number of features)
 0.39.12

--- a/dclab/rtdc_dataset/fmt_hdf5.py
+++ b/dclab/rtdc_dataset/fmt_hdf5.py
@@ -79,6 +79,8 @@ class H5Events:
         elif data.ndim == 1:
             return data[:]
         else:
+            # for features like "image", "image_bg" and other non-scalar
+            # ancillary features
             return data
 
     def __iter__(self):

--- a/dclab/rtdc_dataset/fmt_hdf5.py
+++ b/dclab/rtdc_dataset/fmt_hdf5.py
@@ -70,16 +70,16 @@ class H5Events:
         # user-level checking is done in core.py
         assert dfn.feature_exists(key), "Feature '{}' not valid!".format(key)
         data = self._h5["events"][key]
-        if key in ["image", "image_bg"]:
-            return data
-        elif key == "contour":
+        if key == "contour":
             return H5ContourEvent(data)
         elif key == "mask":
             return H5MaskEvent(data)
         elif key == "trace":
             return H5TraceEvent(data)
-        else:
+        elif data.ndim == 1:
             return data[:]
+        else:
+            return data
 
     def __iter__(self):
         # dict-like behavior

--- a/tests/test_rtdc_feat_anc_plugin.py
+++ b/tests/test_rtdc_feat_anc_plugin.py
@@ -574,13 +574,13 @@ def test_pf_load_non_scalar_plugin_data():
 
     # Exporting the rtdc-file including the plugin-feature and then reloading
     # it should load the non-scalar plugin data as h5py.Dataset
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-        pdir = pathlib.Path(temp_dir)
-        pfile = pdir / "tmp.rtdc"
-        features = ds.features + ["image_gauss_filter"]
-        ds.export.hdf5(pfile, features=features)
-        ds2 = dclab.new_dataset(pfile)
-        assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
+    tdir = tempfile.mkdtemp()
+    pdir = pathlib.Path(tdir)
+    pfile = pdir / "tmp.rtdc"
+    features = ds.features + ["image_gauss_filter"]
+    ds.export.hdf5(pfile, features=features)
+    ds2 = dclab.new_dataset(pfile)
+    assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
 
 
 @pytest.mark.filterwarnings(
@@ -594,13 +594,13 @@ def test_pf_load_scalar_plugin_data():
 
     # Exporting the rtdc-file including the plugin-feature and then reloading
     # it should still load scalar plugin data as np.ndarray
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-        pdir = pathlib.Path(temp_dir)
-        pfile = pdir / "tmp.rtdc"
-        features = ds.features + ["circ_per_area"]
-        ds.export.hdf5(pfile, features=features)
-        ds2 = dclab.new_dataset(pfile)
-        assert isinstance(ds2["circ_per_area"], np.ndarray)
+    tdir = tempfile.mkdtemp()
+    pdir = pathlib.Path(tdir)
+    pfile = pdir / "tmp.rtdc"
+    features = ds.features + ["circ_per_area"]
+    ds.export.hdf5(pfile, features=features)
+    ds2 = dclab.new_dataset(pfile)
+    assert isinstance(ds2["circ_per_area"], np.ndarray)
 
 
 def test_pf_minimum_info_input():

--- a/tests/test_rtdc_feat_anc_plugin.py
+++ b/tests/test_rtdc_feat_anc_plugin.py
@@ -560,6 +560,49 @@ def test_pf_load_plugin():
     assert np.allclose(circ_times_area, ds["circ"] * ds["area_um"])
 
 
+@pytest.mark.filterwarnings(
+    "ignore::dclab.rtdc_dataset.config.WrongConfigurationTypeWarning")
+def test_pf_load_non_scalar_plugin_data():
+    """Test loading non-scalar plugin data format"""
+    ds = dclab.new_dataset(retrieve_data("fmt-hdf5_fl_2018.zip"))
+    info = example_plugin_info_non_scalar_feature()
+    PlugInFeature("image_gauss_filter", info)
+
+    # Accessing non-scalar plugin data without prior saving and storing data in
+    # HDF5-format should return already computed data as np.ndarray
+    assert isinstance(ds["image_gauss_filter"], np.ndarray)
+
+    # Exporting the rtdc-file including the plugin-feature and then reloading
+    # it should load the non-scalar plugin data as h5py.Dataset
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pdir = pathlib.Path(temp_dir)
+        pfile = pdir / "tmp.rtdc"
+        features = ds.features + ["image_gauss_filter"]
+        ds.export.hdf5(pfile, features=features)
+        ds2 = dclab.new_dataset(pfile)
+        assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
+
+
+@pytest.mark.filterwarnings(
+    "ignore::dclab.rtdc_dataset.config.WrongConfigurationTypeWarning")
+def test_pf_load_scalar_plugin_data():
+    """Test loading scalar plugin data return np.ndarray"""
+    ds = dclab.new_dataset(retrieve_data("fmt-hdf5_fl_2018.zip"))
+    info = example_plugin_info_single_feature()
+    PlugInFeature("circ_per_area", info)
+    assert isinstance(ds["circ_per_area"], np.ndarray)
+
+    # Exporting the rtdc-file including the plugin-feature and then reloading
+    # it should still load scalar plugin data as np.ndarray
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pdir = pathlib.Path(temp_dir)
+        pfile = pdir / "tmp.rtdc"
+        features = ds.features + ["circ_per_area"]
+        ds.export.hdf5(pfile, features=features)
+        ds2 = dclab.new_dataset(pfile)
+        assert isinstance(ds2["circ_per_area"], np.ndarray)
+
+
 def test_pf_minimum_info_input():
     """Only method and feature names are required to create PlugInFeature"""
     info = {"method": compute_single_plugin_feature,

--- a/tests/test_rtdc_feat_anc_plugin.py
+++ b/tests/test_rtdc_feat_anc_plugin.py
@@ -579,8 +579,8 @@ def test_pf_load_non_scalar_plugin_data():
         pfile = pdir / "tmp.rtdc"
         features = ds.features + ["image_gauss_filter"]
         ds.export.hdf5(pfile, features=features)
-        ds2 = dclab.new_dataset(pfile)
-        assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
+        with dclab.new_dataset(pfile) as ds2:
+            assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
 
 
 @pytest.mark.filterwarnings(
@@ -599,8 +599,8 @@ def test_pf_load_scalar_plugin_data():
         pfile = pdir / "tmp.rtdc"
         features = ds.features + ["circ_per_area"]
         ds.export.hdf5(pfile, features=features)
-        ds2 = dclab.new_dataset(pfile)
-        assert isinstance(ds2["circ_per_area"], np.ndarray)
+        with dclab.new_dataset(pfile) as ds2:
+            assert isinstance(ds2["circ_per_area"], np.ndarray)
 
 
 def test_pf_minimum_info_input():

--- a/tests/test_rtdc_feat_anc_plugin.py
+++ b/tests/test_rtdc_feat_anc_plugin.py
@@ -574,13 +574,13 @@ def test_pf_load_non_scalar_plugin_data():
 
     # Exporting the rtdc-file including the plugin-feature and then reloading
     # it should load the non-scalar plugin data as h5py.Dataset
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         pdir = pathlib.Path(temp_dir)
         pfile = pdir / "tmp.rtdc"
         features = ds.features + ["image_gauss_filter"]
         ds.export.hdf5(pfile, features=features)
-        with dclab.new_dataset(pfile) as ds2:
-            assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
+        ds2 = dclab.new_dataset(pfile)
+        assert isinstance(ds2["image_gauss_filter"], h5py.Dataset)
 
 
 @pytest.mark.filterwarnings(
@@ -594,13 +594,13 @@ def test_pf_load_scalar_plugin_data():
 
     # Exporting the rtdc-file including the plugin-feature and then reloading
     # it should still load scalar plugin data as np.ndarray
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         pdir = pathlib.Path(temp_dir)
         pfile = pdir / "tmp.rtdc"
         features = ds.features + ["circ_per_area"]
         ds.export.hdf5(pfile, features=features)
-        with dclab.new_dataset(pfile) as ds2:
-            assert isinstance(ds2["circ_per_area"], np.ndarray)
+        ds2 = dclab.new_dataset(pfile)
+        assert isinstance(ds2["circ_per_area"], np.ndarray)
 
 
 def test_pf_minimum_info_input():

--- a/tests/test_rtdc_fmt_hdf5.py
+++ b/tests/test_rtdc_fmt_hdf5.py
@@ -131,6 +131,15 @@ def test_hash():
 
 @pytest.mark.filterwarnings(
     "ignore::dclab.rtdc_dataset.config.WrongConfigurationTypeWarning")
+def test_hdf5_load_non_scalar_data():
+    """Loading non-scalar data should return data as h5py.Dataset"""
+    ds = new_dataset(retrieve_data("fmt-hdf5_image-bg_2020.zip"))
+    assert isinstance(ds["image"], h5py.Dataset)
+    assert isinstance(ds["image_bg"], h5py.Dataset)
+
+
+@pytest.mark.filterwarnings(
+    "ignore::dclab.rtdc_dataset.config.WrongConfigurationTypeWarning")
 def test_hdf5_shape_contour():
     ds = new_dataset(retrieve_data("fmt-hdf5_mask-contour_2018.zip"))
     assert "contour" in ds.features_innate


### PR DESCRIPTION
Data from a plugin feature can be stored in an RTDC-file when exporting a RTDC-dataset with non-scalar plugin features or appending the data to an existing one. 
When loading this RTDC-dataset again and accessing a non-scalar plugin feature this would load the data as an np.ndarray, instead of an h5py.Dataset, and thus load the complete data into memory before accessing slices or single entries. This is unnecessary and sometimes even leads to memory issues.

To fix this, non-scalar features are loaded as h5py.Datasets instead, like it was the case already for non-scalar features `image` and `image_bg`.

Closes #162