### PR TITLE
docs: make compilation run on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/my-data.rtdc
 docs/export_example.rtdc
 docs/export_example.tsv
 docs/dclab.bib.sav

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.46.3
+ - docs: make compilation run on Windows
 0.46.2
  - fix: support passing instances of `Configuration` and
    `ConfigurationDict` to `dclab.util.obj2bytes`

--- a/docs/sec_av_rtdc_dataset.rst
+++ b/docs/sec_av_rtdc_dataset.rst
@@ -52,13 +52,13 @@ make use of the :class:`RTDCWriter <dclab.rtdc_dataset.writer.RTDCWriter>` class
 
 .. ipython::
 
-    In [4]: with dclab.RTDCWriter("/tmp/my-data.rtdc", mode="reset") as hw:
+    In [4]: with dclab.RTDCWriter("my-data.rtdc", mode="reset") as hw:
        ...:     hw.store_metadata({"experiment": {"sample": "my sample",
        ...:                                       "run index": 1}})
        ...:     hw.store_feature("deform", np.random.rand(100))
        ...:     hw.store_feature("area_um", np.random.rand(100))
 
-    In [5]: ds_custom = dclab.new_dataset("/tmp/my-data.rtdc")
+    In [5]: ds_custom = dclab.new_dataset("my-data.rtdc")
 
     In [6]: print(ds_custom.features)
 


### PR DESCRIPTION
When installing dclab and running tests and compiling the docs I noticed that the docs would not compile. Some code in `sec_av_rtdc_dataset.rst` wanted to access the directory `/tmp/` to create an .rtdc file. Since this directory does not exist per default on Windows, it resulted in an FileNotFoundError. Changed the code such that the .rtdc file is created in the docs's directory and added this file to the .gitignore. Compilation seems to work now. 