### PR TITLE
Update information about plugin features (#151)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.46.3
  - docs: make compilation run on Windows
+ - docs: update information on plugin features (#151)
 0.46.2
  - fix: support passing instances of `Configuration` and
    `ConfigurationDict` to `dclab.util.obj2bytes`

--- a/dclab/rtdc_dataset/feat_anc_plugin/plugin_feature.py
+++ b/dclab/rtdc_dataset/feat_anc_plugin/plugin_feature.py
@@ -32,6 +32,10 @@ def import_plugin_feature_script(plugin_path):
     ------
     PluginImportError
         If the plugin can not be found
+
+    Notes
+    -----
+    There can be several plugin features being calculated in one recipe.
     """
     path = pathlib.Path(plugin_path)
     if not path.exists():
@@ -70,6 +74,10 @@ def load_plugin_feature(plugin_path):
     ------
     ValueError
         If the script dictionary "feature names" are not a list
+
+    Notes
+    -----
+    There can be several plugin features being calculated in one recipe.
 
     See Also
     --------

--- a/dclab/rtdc_dataset/feat_anc_plugin/plugin_feature.py
+++ b/dclab/rtdc_dataset/feat_anc_plugin/plugin_feature.py
@@ -35,7 +35,7 @@ def import_plugin_feature_script(plugin_path):
 
     Notes
     -----
-    There can be several plugin features being calculated in one recipe.
+    One recipe may define multiple plugin features.
     """
     path = pathlib.Path(plugin_path)
     if not path.exists():
@@ -77,7 +77,7 @@ def load_plugin_feature(plugin_path):
 
     Notes
     -----
-    There can be several plugin features being calculated in one recipe.
+    One recipe may define multiple plugin features.
 
     See Also
     --------

--- a/docs/sec_av_feat_plugin.rst
+++ b/docs/sec_av_feat_plugin.rst
@@ -62,12 +62,15 @@ Writing a plugin feature recipe
 ===============================
 A plugin feature recipe is defined in a Python script (e.g. `my_dclab_plugin.py`).
 A plugin feature recipe contains a function and an ``info`` dictionary.
-The function calculates the desired feature, and the dictionary defines
-any extra (meta-)information of the feature. Both "method" (the function)
-and "feature names" must be included in the ``info`` dictionary.
+The function calculates the desired feature and can even calculate several
+features, while  the dictionary defines any extra (meta-)information of the
+calculated feature (or features).
+Both, "method" (the function) and "feature names", must be included in the
+``info`` dictionary.
 Note that many of the items in the dictionary must be lists!
-Also note that a feature recipe may contain *multiple* features.
-Below are three examples of creating and using plugin features.
+Also note that in case a feature recipe contains *multiple* features, there
+must be only one function for their calculation and only one ``info``
+dictionary. Below are three examples of creating and using plugin features.
 
 .. note::
 
@@ -89,12 +92,12 @@ Advanced plugin feature recipe
 In :download:`this example <../examples/plugin_example.py>`, the function
 :func:`compute_some_new_features` defines two basic features:
 `"circ_per_area"` and `"circ_times_area"`. Notice that both features are
-computed in one function:
+computed in one function and that there is only one ``info`` dictionary:
 
 .. literalinclude:: ../examples/plugin_example.py
    :language: python
 
-Here, all possible keys in the `info` dictionaryare shown (but not all are used).
+Here, all possible keys in the `info` dictionary are shown (but not all are used).
 The keys are additional keyword arguments to the
 :class:`AncillaryFeature <dclab.rtdc_dataset.feat_anc_core.ancillary_feature.AncillaryFeature>`
 class:


### PR DESCRIPTION
This PR aims to update the docs and docstrings about plugin features to make clear that one recipe should have only one function that calculates one or several plugin features and also only one info dictionary with meta information about the plugin feature(s).

This addresses #151 